### PR TITLE
add udevadm command to notify Xorg after change of keyboard layout

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -190,7 +190,8 @@ do_change_pass() {
 do_configure_keyboard() {
   dpkg-reconfigure keyboard-configuration &&
   printf "Reloading keymap. This may take a short while\n" &&
-  invoke-rc.d keyboard-setup start
+  invoke-rc.d keyboard-setup start &&
+  udevadm trigger --subsystem-match=input --action=change
 }
 
 do_change_locale() {

--- a/raspi-config
+++ b/raspi-config
@@ -190,8 +190,9 @@ do_change_pass() {
 do_configure_keyboard() {
   dpkg-reconfigure keyboard-configuration &&
   printf "Reloading keymap. This may take a short while\n" &&
-  invoke-rc.d keyboard-setup start &&
+  invoke-rc.d keyboard-setup start || return $?
   udevadm trigger --subsystem-match=input --action=change
+  return 0
 }
 
 do_change_locale() {


### PR DESCRIPTION
If the keyboard layout is changed after X11 has launched (with startx, or because boot to desktop has been selected on an earlier boot), Xorg does not recognise the keyboard change until the next restart (or physical re-plug of the keyboard).

Rather than force a reboot after every change, I believe this udevadm command is a sufficient fix.