### PR TITLE
Add command line argument to enable camera in non interactive mode

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -1047,6 +1047,12 @@ do
     do_apply_os_config
     exit $?
     ;;
+  --enable-camera)
+    INTERACTIVE=False
+    printf "Please reboot\n"
+    set_camera 1
+    exit $?
+    ;;
   nonint)
     INTERACTIVE=False
     $@


### PR DESCRIPTION
Added command line argument to activate the camera in non interactive mode

```
sudo ./raspi-config --enable-camera
```
Can be useful if the raspberry pi will be configured by script