### PR TITLE
Make dependency on triggerhappy optional

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+raspi-config (20160429) UNRELEASED; urgency=medium
+
+  * Downgrade hard dependency on triggerhappy to recommendation.
+    + init script: Check if thd is present before using it.
+
+ -- Axel Beckert <abe@debian.org>  Thu, 05 May 2016 20:57:55 +0200
+
 raspi-config (20160428) jessie; urgency=medium
 
   * [Simon Long]

--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,7 @@ Vcs-Browser: https://github.com/RPi-Distro/raspi-config
 
 Package: raspi-config
 Architecture: all
-Depends: ${misc:Depends}, whiptail, parted, lua5.1, triggerhappy, alsa-utils
+Depends: ${misc:Depends}, whiptail, parted, lua5.1, alsa-utils
+Recommends: triggerhappy
 Description: Raspberry Pi configuration tool
  A simple configuration tool for common Raspberry Pi administrative tasks

--- a/debian/raspi-config.init
+++ b/debian/raspi-config.init
@@ -14,8 +14,7 @@
 case "$1" in
   start)
     log_daemon_msg "Checking if shift key is held down"
-    timeout 1 thd --dump /dev/input/event* | grep -q "LEFTSHIFT\|RIGHTSHIFT"
-    if [ $? -eq 0 ]; then
+    if [ -x /usr/sbin/thd ] && timeout 1 thd --dump /dev/input/event* | grep -q "LEFTSHIFT\|RIGHTSHIFT"; then
       printf " Yes. Not enabling ondemand scaling governor"
       log_end_msg 0
     else


### PR DESCRIPTION
The idea to this pull request was sparked by [this question on RaspberryPi.SE why raspi-config depends on triggerhappy](https://raspberrypi.stackexchange.com/questions/46823/why-does-raspi-config-depend-on-triggerhappy).

It downgrades the hard dependency on triggerhappy to a recommendation by first checking if `thd` is present before using it in the init script.

The patch is currently untested since I currently only have remote access to my Raspberry Pis, but I'll test it the next time I have physical access to them. I'll then remove or replace this paragraph. 