### PR TITLE
[Issue #39] Allow do_audio() to be called non-interactively.

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -1194,11 +1194,15 @@ do_update() {
 }
 
 do_audio() {
-  AUDIO_OUT=$(whiptail --menu "Choose the audio output" 20 60 10 \
-    "0" "Auto" \
-    "1" "Force 3.5mm ('headphone') jack" \
-    "2" "Force HDMI" \
-    3>&1 1>&2 2>&3)
+  if [ "$INTERACTIVE" = True ]; then
+    AUDIO_OUT=$(whiptail --menu "Choose the audio output" 20 60 10 \
+      "0" "Auto" \
+      "1" "Force 3.5mm ('headphone') jack" \
+      "2" "Force HDMI" \
+      3>&1 1>&2 2>&3)
+  else
+    AUDIO_OUT=$1
+  fi
   if [ $? -eq 0 ]; then
     amixer cset numid=3 "$AUDIO_OUT"
   fi


### PR DESCRIPTION
I changed the do_audio() function to allow it to be called non-interactively. This is a fix for Issue #39. I tested my changes on a Raspberry Pi 3 to make sure that setting audio output interactively and non-interactively works as expected.