### PR TITLE
Use --follow-symlinks option in sed to keep symlink

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -351,9 +351,9 @@ do_wifi_country() {
   if [ $? -eq 0 ];then
     if [ -e /etc/wpa_supplicant/wpa_supplicant.conf ]; then
         if grep -q "^country=" /etc/wpa_supplicant/wpa_supplicant.conf ; then
-            sed -i "s/^country=.*/country=$COUNTRY/g" /etc/wpa_supplicant/wpa_supplicant.conf
+            sed -i --follow-symlinks "s/^country=.*/country=$COUNTRY/g" /etc/wpa_supplicant/wpa_supplicant.conf
         else
-            sed -i "1i country=$COUNTRY" /etc/wpa_supplicant/wpa_supplicant.conf
+            sed -i --follow-symlinks "1i country=$COUNTRY" /etc/wpa_supplicant/wpa_supplicant.conf
         fi
     else
         echo "country=$COUNTRY" > /etc/wpa_supplicant/wpa_supplicant.conf


### PR DESCRIPTION
In [OctoPi](https://github.com/guysoft/OctoPi) we symlink `/etc/wpa_supplicant/wpa_supplicant.conf` to `/boot` so that users can change SSID/password without booting into raspbian.

However this symlink will be broken by `raspi-config` because of the default behavior of `sed` in handling symlink. 

The issue is described in detail [here](https://github.com/guysoft/OctoPi/issues/336).

This PR is to add option `--follow-symlinks` option to `sed` so that it will honor symlinks.