### PR TITLE
Allow the path for config.txt to be an optional parameter

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -6,7 +6,7 @@
 INTERACTIVE=True
 ASK_TO_REBOOT=0
 BLACKLIST=/etc/modprobe.d/raspi-blacklist.conf
-CONFIG=/boot/config.txt
+CONFIG=${1:-/boot/config.txt}
 
 is_pi () {
 	grep -q "^model name\s*:\s*ARMv" /proc/cpuinfo


### PR DESCRIPTION
If the system is booting off of a USB stick then the `/boot` folder used by `raspi-config` may not be the actual partition used by the firmware at boot time, so any changes will have zero effect.

This change lets the user specify the `config.txt` file path to use, if it is not specified then the default `/boot/config.txt` is used instead.

e.g.  after manually mounting the 'real' /boot partition of the SDcard:
```
sudo mkdir /mnt/sdcard_boot
sudo mount /dev/mmcblk0p1 /mnt/sdcard_boot
```

Then `raspi-config` can be run with:
```
sudo raspi-config /mnt/sdcard_boot/config.txt 
```