### PR TITLE
Allow entering SSID and passphrase, appending network blocks to wpa_supplicant.conf

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -1294,6 +1294,110 @@ do_resolution() {
   fi
 }
 
+remove_network_block() {
+  # Escape special characters to avoid screwing up regex below
+  # Escape '\' separately because it would mix up with others
+  local ssid=$(echo "$1" | sed 's;\\;\\\\;g' | sed -e 's;\.;\\\.;g'  \
+                                                   -e 's;\*;\\\*;g'  \
+                                                   -e 's;\+;\\\+;g'  \
+                                                   -e 's;\?;\\\?;g'  \
+                                                   -e 's;\^;\\\^;g'  \
+                                                   -e 's;\$;\\\$;g'  \
+                                                   -e 's;\/;\\\/;g'  \
+                                                   -e 's;\[;\\\[;g'  \
+                                                   -e 's;\];\\\];g'  \
+                                                   -e 's;{;\\{;g'    \
+                                                   -e 's;};\\};g'    \
+                                                   -e 's;(;\\(;g'    \
+                                                   -e 's;);\\);g')
+
+  # Match the following and remove it:
+  # ^\s*network=\{        ==>  network block begins
+  # (?:(?!^\s*\}.*$).)*?  ==>  no block ending in between
+  # ^\s*ssid="..."        ==>  target SSID
+  # ^\s*\}                ==>  network block ends
+  perl -i -pe 'BEGIN{undef $/;} s/^\s*network=\{(?:(?!^\s*\}.*$).)*?^\s*ssid="'$ssid'".*?^\s*\}.*?\n//smg' /etc/wpa_supplicant/wpa_supplicant.conf
+}
+
+append_nokey_network_block() {
+  local ssid=$1
+  
+  cat <<EOT >> /etc/wpa_supplicant/wpa_supplicant.conf
+network={
+    ssid="$ssid"
+    key_mgmt=NONE
+}
+EOT
+}
+
+append_wpa_network_block() {
+  local ssid=$1
+  local passphrase=$2
+  local out=
+
+  if out=$(wpa_passphrase "$ssid" "$passphrase"); then
+    echo "$out" | tee -a /etc/wpa_supplicant/wpa_supplicant.conf > /dev/null
+  fi
+}
+
+do_wifi_ssid_passphrase() {
+  HOTSPOTS=$(iwlist wlan0 scan |
+             grep -e ESSID -e Quality |
+             sed 'N;s/\n//' |    # merge SSID and Quality into one line
+             sed 's/^.*Quality=\([0-9\/]*\).*ESSID:"\(.*\)".*$/\2 \1/')
+
+  # What if SSID contains spaces or double-quotes?
+
+  if [ -z "$HOTSPOTS" ]; then
+    whiptail --yesno "No hotspot found. Do you want to enter SSID manually?" 20 60
+    if [ $? -ne 0 ]; then
+      return 0
+    else
+      SSID=
+    fi
+  else
+    SSID=$(whiptail --menu "Pick a hotspot" 20 60 10 --cancel-button "Enter SSID manually" --ok-button Select \
+      $HOTSPOTS \
+      3>&1 1>&2 2>&3)
+    RET=$?
+    if [ $RET -eq 1 ]; then
+      SSID=
+    elif [ $RET -ne 0 ]; then
+      return 0
+    fi
+  fi
+
+  while [ -z "$SSID" ]; do
+    SSID=$(whiptail --inputbox "Please enter SSID" 20 60 3>&1 1>&2 2>&3)
+    if [ $? -ne 0 ]; then
+      return 0
+    elif [ -z "$SSID" ]; then
+      whiptail --msgbox "SSID cannot be empty. Please try again." 20 60
+    fi
+  done
+
+  while true; do
+    PASSPHRASE=$(whiptail --passwordbox "Please enter passphrase. Leave it empty if none." 20 60 3>&1 1>&2 2>&3)
+    if [ $? -ne 0 ]; then
+      return 0
+    elif [ -z "$PASSPHRASE" ] || WPA_OUT=$(wpa_passphrase "$SSID" "$PASSPHRASE"); then
+      break
+    else
+      whiptail --msgbox "${WPA_OUT}. Please try again." 20 60
+    fi
+  done
+
+  remove_network_block "$SSID"
+
+  if [ -z "$PASSPHRASE" ]; then
+    append_nokey_network_block "$SSID"
+  else
+    append_wpa_network_block "$SSID" "$PASSPHRASE"
+  fi
+
+  ASK_TO_REBOOT=1
+}
+
 do_finish() {
   disable_raspi_config_at_boot
   if [ $ASK_TO_REBOOT -eq 1 ]; then
@@ -1519,7 +1623,6 @@ do_advanced_menu() {
     "A4 Audio" "Force audio out through HDMI or 3.5mm jack" \
     "A5 Resolution" "Set a specific screen resolution" \
     "A6 GL Driver" "Enable/Disable experimental desktop GL driver" \
-    "A7 Network interface names" "Enable/Disable predictable network interface names" \
     3>&1 1>&2 2>&3)
   RET=$?
   if [ $RET -eq 1 ]; then
@@ -1532,7 +1635,6 @@ do_advanced_menu() {
       A4\ *) do_audio ;;
       A5\ *) do_resolution ;;
       A6\ *) do_gldriver ;;
-      A7\ *) do_net_names ;;
       *) whiptail --msgbox "Programmer error: unrecognized option" 20 60 1 ;;
     esac || whiptail --msgbox "There was an error running option $FUN" 20 60 1
   fi
@@ -1564,6 +1666,25 @@ do_boot_menu() {
   fi
 }
 
+do_network_menu() {
+  FUN=$(whiptail --title "Raspberry Pi Software Configuration Tool (raspi-config)" --menu "Network Options" $WT_HEIGHT $WT_WIDTH $WT_MENU_HEIGHT --cancel-button Back --ok-button Select \
+    "N1 Hostname" "Set the visible name for this Pi on a network" \
+    "N2 Wi-fi" "Enter SSID and passphrase" \
+    "N3 Network interface names" "Enable/Disable predictable network interface names" \
+    3>&1 1>&2 2>&3)
+  RET=$?
+  if [ $RET -eq 1 ]; then
+    return 0
+  elif [ $RET -eq 0 ]; then
+    case "$FUN" in
+      N1\ *) do_hostname ;;
+      N2\ *) do_wifi_ssid_passphrase ;;
+      N3\ *) do_net_names ;;
+      *) whiptail --msgbox "Programmer error: unrecognized option" 20 60 1 ;;
+    esac || whiptail --msgbox "There was an error running option $FUN" 20 60 1
+  fi
+}
+
 #
 # Interactive use loop
 #
@@ -1578,7 +1699,7 @@ if [ "$INTERACTIVE" = True ]; then
 	if is_pi ; then
       FUN=$(whiptail --title "Raspberry Pi Software Configuration Tool (raspi-config)" --backtitle "$(cat /proc/device-tree/model)" --menu "Setup Options" $WT_HEIGHT $WT_WIDTH $WT_MENU_HEIGHT --cancel-button Finish --ok-button Select \
         "1 Change User Password" "Change password for the current user" \
-        "2 Hostname" "Set the visible name for this Pi on a network" \
+        "2 Network Options" "Configure network settings" \
         "3 Boot Options" "Configure options for start-up" \
         "4 Localisation Options" "Set up language and regional settings to match your location" \
         "5 Interfacing Options" "Configure connections to peripherals" \
@@ -1604,7 +1725,7 @@ if [ "$INTERACTIVE" = True ]; then
     elif [ $RET -eq 0 ]; then
       case "$FUN" in
         1\ *) do_change_pass ;;
-        2\ *) do_hostname ;;
+        2\ *) do_network_menu ;;
         3\ *) do_boot_menu ;;
         4\ *) do_internationalisation_menu ;;
         5\ *) do_interface_menu ;;


### PR DESCRIPTION
It took more than a few days, but here we go.

Replacing the top-level menu item `Hostname` is the new `Network Options`, which includes under it:
- Hostname
- Wi-fi SSID and passphrase
- Predictable network interface names

On entering the Wi-fi SSID option, here is the sequence you will encounter:

1. A Wi-fi scan is done on `wlan0`, and hotspots are displayed. Users may **select a hotspot**, or choose to **enter SSID manually**
    - If no hotspot is found, users are notified accordingly, and are given the choice to enter SSID manually
    - If no `wlan0` exists in the first place, it will be the same as if no hotspot is found. 

2. On **selecting a hotspot** or having **entered an SSID manually**, users are prompted for a passphrase. It may be left empty if no passphrase is required.

3. On receiving the SSID and passphrase, the program tries to remove any existing network block belonging to that SSID (more on this below), before appending a network block to the file `/etc/wpa_supplicant/wpa_supplicant.conf`.
    - If passphrase is empty, this block is inserted:
        ```
        network={
            ssid="..."
            key_mgmt=NONE
        }
        ```
    - Otherwise, the output of `wpa_passphrase ssid passphrase` is inserted.

In case anyone asks about WEP networks and hidden SSID, I am not going to provide them at this moment. This feature is intended to be a convenience that works for common situations. For unrestrained power, users are encouraged (to learn) to modify files by hand.

It's also worth noting that appending a network block does not necessarily make the machine connect to that SSID, because `wpa_supplicant.conf` may contain other SSIDs that are equally in range. It's up to the user to set `priority` in the network blocks.

Reliably removing an existing network block proves to be quite a challenge. It's hard to use `sed` to do non-trivial multi-line matching, so **I use `perl`**. Because an SSID may contain arbitrary characters, I have to escape special characters in the SSID before embedding it in the regex so it won't screw up the regex.

A **bug** lurks in the wifi scanning/hotspot displaying part (step 1 above). I extract SSID and their signal quality from `sudo iwlist wlan0 scan`, then embed the results in a whiptail menu as tag-item pairs. What if an SSID contains whitespaces or double-quotes? I have tried to surround SSID with double-quotes during the extraction, but the double-quotes appear in the whiptail menu! I have also put a hotspot with an SSID containg a space next to my Raspberry Pi, and it does cause step 1 to fail. **I need help fixing this.**

Thanks in advance :blush: 