### PR TITLE
Allow entering SSID and passphrase

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -1336,7 +1336,7 @@ append_wpa_network_block() {
   local out=
 
   if out=$(wpa_passphrase "$ssid" "$passphrase"); then
-    echo "$out" | tee -a /etc/wpa_supplicant/wpa_supplicant.conf > /dev/null
+    echo "$out" >> /etc/wpa_supplicant/wpa_supplicant.conf
   fi
 }
 
@@ -1370,9 +1370,8 @@ do_wifi_ssid_passphrase() {
     append_wpa_network_block "$SSID" "$PASSPHRASE"
   fi
 
-  if ifconfig wlan0 > /dev/null 2>&1; then
-    wpa_cli -i wlan0 reconfigure > /dev/null
-  fi
+  wpa_cli -i wlan0 reconfigure >/dev/null 2>&1
+  return 0
 }
 
 do_finish() {

--- a/raspi-config
+++ b/raspi-config
@@ -1317,6 +1317,7 @@ do_wifi_ssid_passphrase() {
     return 1
   fi
 
+  SSID=
   while [ -z "$SSID" ]; do
     SSID=$(whiptail --inputbox "Please enter SSID" 20 60 3>&1 1>&2 2>&3)
     if [ $? -ne 0 ]; then
@@ -1335,8 +1336,26 @@ do_wifi_ssid_passphrase() {
     fi
   done
 
+  # Escape special characters for embedding in regex below
+  local ssid=$(echo "$SSID" \
+   | sed 's;\\;\\\\;g' \
+   | sed -e 's;\.;\\\.;g' \
+         -e 's;\*;\\\*;g' \
+         -e 's;\+;\\\+;g' \
+         -e 's;\?;\\\?;g' \
+         -e 's;\^;\\\^;g' \
+         -e 's;\$;\\\$;g' \
+         -e 's;\/;\\\/;g' \
+         -e 's;\[;\\\[;g' \
+         -e 's;\];\\\];g' \
+         -e 's;{;\\{;g'   \
+         -e 's;};\\};g'   \
+         -e 's;(;\\(;g'   \
+         -e 's;);\\);g'   \
+         -e 's;";\\\\\";g')
+
   wpa_cli -i "$IFACE" list_networks \
-   | tail -n +2 | cut -f -2 | grep -P "\t$SSID$" | cut -f1 \
+   | tail -n +2 | cut -f -2 | grep -P "\t$ssid$" | cut -f1 \
    | while read ID; do
     wpa_cli -i "$IFACE" remove_network "$ID" > /dev/null 2>&1
   done

--- a/raspi-config
+++ b/raspi-config
@@ -1294,54 +1294,29 @@ do_resolution() {
   fi
 }
 
-remove_network_block() {
-  # Escape special characters to avoid screwing up regex below
-  # Escape '\' separately because it would mix up with others
-  local ssid=$(echo "$1" | sed 's;\\;\\\\;g' | sed -e 's;\.;\\\.;g'  \
-                                                   -e 's;\*;\\\*;g'  \
-                                                   -e 's;\+;\\\+;g'  \
-                                                   -e 's;\?;\\\?;g'  \
-                                                   -e 's;\^;\\\^;g'  \
-                                                   -e 's;\$;\\\$;g'  \
-                                                   -e 's;\/;\\\/;g'  \
-                                                   -e 's;\[;\\\[;g'  \
-                                                   -e 's;\];\\\];g'  \
-                                                   -e 's;{;\\{;g'    \
-                                                   -e 's;};\\};g'    \
-                                                   -e 's;(;\\(;g'    \
-                                                   -e 's;);\\);g')
-
-  # Match the following and remove it:
-  # ^\s*network=\{        ==>  network block begins
-  # (?:(?!^\s*\}.*$).)*?  ==>  no block ending in between
-  # ^\s*ssid="..."        ==>  target SSID
-  # ^\s*\}                ==>  network block ends
-  perl -i -pe 'BEGIN{undef $/;} s/^\s*network=\{(?:(?!^\s*\}.*$).)*?^\s*ssid="'$ssid'".*?^\s*\}.*?\n//smg' /etc/wpa_supplicant/wpa_supplicant.conf
-}
-
-append_nokey_network_block() {
-  local ssid=$1
-
-  cat <<EOT >> /etc/wpa_supplicant/wpa_supplicant.conf
-network={
-    ssid="$ssid"
-    key_mgmt=NONE
-}
-EOT
-}
-
-append_wpa_network_block() {
-  local ssid=$1
-  local passphrase=$2
-  local out=
-
-  if out=$(wpa_passphrase "$ssid" "$passphrase"); then
-    echo "$out" >> /etc/wpa_supplicant/wpa_supplicant.conf
-  fi
+list_wlan_interfaces() {
+  for dir in /sys/class/net/*/wireless; do
+    if [ -d "$dir" ]; then
+      basename "$(dirname "$dir")"
+    fi
+  done
 }
 
 do_wifi_ssid_passphrase() {
-  SSID=
+  RET=0
+  IFACE_LIST="$(list_wlan_interfaces)"
+  IFACE="$(echo "$IFACE_LIST" | head -n 1)"
+
+  if [ -z "$IFACE" ]; then
+    whiptail --msgbox "No wireless interface found" 20 60
+    return 1
+  fi
+
+  if ! wpa_cli -i "$IFACE" status > /dev/null 2>&1; then
+    whiptail --msgbox "Could not communicate with wpa_supplicant" 20 60
+    return 1
+  fi
+
   while [ -z "$SSID" ]; do
     SSID=$(whiptail --inputbox "Please enter SSID" 20 60 3>&1 1>&2 2>&3)
     if [ $? -ne 0 ]; then
@@ -1355,23 +1330,42 @@ do_wifi_ssid_passphrase() {
     PASSPHRASE=$(whiptail --passwordbox "Please enter passphrase. Leave it empty if none." 20 60 3>&1 1>&2 2>&3)
     if [ $? -ne 0 ]; then
       return 0
-    elif [ -z "$PASSPHRASE" ] || WPA_OUT=$(wpa_passphrase "$SSID" "$PASSPHRASE"); then
-      break
     else
-      whiptail --msgbox "${WPA_OUT}. Please try again." 20 60
+      break
     fi
   done
 
-  remove_network_block "$SSID"
+  wpa_cli -i "$IFACE" list_networks \
+   | tail -n +2 | cut -f -2 | grep -P "\t$SSID$" | cut -f1 \
+   | while read ID; do
+    wpa_cli -i "$IFACE" remove_network "$ID"
+  done
+
+  ID="$(wpa_cli -i "$IFACE" add_network)"
+  wpa_cli -i "$IFACE" set_network "$ID" ssid "\"$SSID\"" 2>&1 | grep -q "OK"
+  RET=$((RET + $?))
 
   if [ -z "$PASSPHRASE" ]; then
-    append_nokey_network_block "$SSID"
+    wpa_cli -i "$IFACE" set_network "$ID" key_mgmt NONE 2>&1 | grep -q "OK"
+    RET=$((RET + $?))
   else
-    append_wpa_network_block "$SSID" "$PASSPHRASE"
+    wpa_cli -i "$IFACE" set_network "$ID" psk "\"$PASSPHRASE\"" 2>&1 | grep -q "OK"
+    RET=$((RET + $?))
   fi
 
-  wpa_cli -i wlan0 reconfigure >/dev/null 2>&1
-  return 0
+  if [ $RET -eq 0 ]; then
+    wpa_cli -i "$IFACE" enable_network "$ID"
+  else
+    wpa_cli -i "$IFACE" remove_network "$ID"
+    whiptail --msgbox "Failed to set SSID or passphrase" 20 60
+  fi
+  wpa_cli -i "$IFACE" save_config
+
+  echo "$IFACE_LIST" | while read IFACE; do
+    wpa_cli -i "$IFACE" reconfigure
+  done
+
+  return $RET
 }
 
 do_finish() {

--- a/raspi-config
+++ b/raspi-config
@@ -1338,7 +1338,7 @@ do_wifi_ssid_passphrase() {
   wpa_cli -i "$IFACE" list_networks \
    | tail -n +2 | cut -f -2 | grep -P "\t$SSID$" | cut -f1 \
    | while read ID; do
-    wpa_cli -i "$IFACE" remove_network "$ID"
+    wpa_cli -i "$IFACE" remove_network "$ID" > /dev/null 2>&1
   done
 
   ID="$(wpa_cli -i "$IFACE" add_network)"
@@ -1354,15 +1354,15 @@ do_wifi_ssid_passphrase() {
   fi
 
   if [ $RET -eq 0 ]; then
-    wpa_cli -i "$IFACE" enable_network "$ID"
+    wpa_cli -i "$IFACE" enable_network "$ID" > /dev/null 2>&1
   else
-    wpa_cli -i "$IFACE" remove_network "$ID"
+    wpa_cli -i "$IFACE" remove_network "$ID" > /dev/null 2>&1
     whiptail --msgbox "Failed to set SSID or passphrase" 20 60
   fi
-  wpa_cli -i "$IFACE" save_config
+  wpa_cli -i "$IFACE" save_config > /dev/null 2>&1
 
   echo "$IFACE_LIST" | while read IFACE; do
-    wpa_cli -i "$IFACE" reconfigure
+    wpa_cli -i "$IFACE" reconfigure > /dev/null 2>&1
   done
 
   return $RET

--- a/raspi-config
+++ b/raspi-config
@@ -1294,6 +1294,87 @@ do_resolution() {
   fi
 }
 
+remove_network_block() {
+  # Escape special characters to avoid screwing up regex below
+  # Escape '\' separately because it would mix up with others
+  local ssid=$(echo "$1" | sed 's;\\;\\\\;g' | sed -e 's;\.;\\\.;g'  \
+                                                   -e 's;\*;\\\*;g'  \
+                                                   -e 's;\+;\\\+;g'  \
+                                                   -e 's;\?;\\\?;g'  \
+                                                   -e 's;\^;\\\^;g'  \
+                                                   -e 's;\$;\\\$;g'  \
+                                                   -e 's;\/;\\\/;g'  \
+                                                   -e 's;\[;\\\[;g'  \
+                                                   -e 's;\];\\\];g'  \
+                                                   -e 's;{;\\{;g'    \
+                                                   -e 's;};\\};g'    \
+                                                   -e 's;(;\\(;g'    \
+                                                   -e 's;);\\);g')
+
+  # Match the following and remove it:
+  # ^\s*network=\{        ==>  network block begins
+  # (?:(?!^\s*\}.*$).)*?  ==>  no block ending in between
+  # ^\s*ssid="..."        ==>  target SSID
+  # ^\s*\}                ==>  network block ends
+  perl -i -pe 'BEGIN{undef $/;} s/^\s*network=\{(?:(?!^\s*\}.*$).)*?^\s*ssid="'$ssid'".*?^\s*\}.*?\n//smg' /etc/wpa_supplicant/wpa_supplicant.conf
+}
+
+append_nokey_network_block() {
+  local ssid=$1
+
+  cat <<EOT >> /etc/wpa_supplicant/wpa_supplicant.conf
+network={
+    ssid="$ssid"
+    key_mgmt=NONE
+}
+EOT
+}
+
+append_wpa_network_block() {
+  local ssid=$1
+  local passphrase=$2
+  local out=
+
+  if out=$(wpa_passphrase "$ssid" "$passphrase"); then
+    echo "$out" | tee -a /etc/wpa_supplicant/wpa_supplicant.conf > /dev/null
+  fi
+}
+
+do_wifi_ssid_passphrase() {
+  SSID=
+  while [ -z "$SSID" ]; do
+    SSID=$(whiptail --inputbox "Please enter SSID" 20 60 3>&1 1>&2 2>&3)
+    if [ $? -ne 0 ]; then
+      return 0
+    elif [ -z "$SSID" ]; then
+      whiptail --msgbox "SSID cannot be empty. Please try again." 20 60
+    fi
+  done
+
+  while true; do
+    PASSPHRASE=$(whiptail --passwordbox "Please enter passphrase. Leave it empty if none." 20 60 3>&1 1>&2 2>&3)
+    if [ $? -ne 0 ]; then
+      return 0
+    elif [ -z "$PASSPHRASE" ] || WPA_OUT=$(wpa_passphrase "$SSID" "$PASSPHRASE"); then
+      break
+    else
+      whiptail --msgbox "${WPA_OUT}. Please try again." 20 60
+    fi
+  done
+
+  remove_network_block "$SSID"
+
+  if [ -z "$PASSPHRASE" ]; then
+    append_nokey_network_block "$SSID"
+  else
+    append_wpa_network_block "$SSID" "$PASSPHRASE"
+  fi
+
+  if ifconfig wlan0 > /dev/null 2>&1; then
+    wpa_cli -i wlan0 reconfigure > /dev/null
+  fi
+}
+
 do_finish() {
   disable_raspi_config_at_boot
   if [ $ASK_TO_REBOOT -eq 1 ]; then
@@ -1519,7 +1600,6 @@ do_advanced_menu() {
     "A4 Audio" "Force audio out through HDMI or 3.5mm jack" \
     "A5 Resolution" "Set a specific screen resolution" \
     "A6 GL Driver" "Enable/Disable experimental desktop GL driver" \
-    "A7 Network interface names" "Enable/Disable predictable network interface names" \
     3>&1 1>&2 2>&3)
   RET=$?
   if [ $RET -eq 1 ]; then
@@ -1532,7 +1612,6 @@ do_advanced_menu() {
       A4\ *) do_audio ;;
       A5\ *) do_resolution ;;
       A6\ *) do_gldriver ;;
-      A7\ *) do_net_names ;;
       *) whiptail --msgbox "Programmer error: unrecognized option" 20 60 1 ;;
     esac || whiptail --msgbox "There was an error running option $FUN" 20 60 1
   fi
@@ -1564,6 +1643,25 @@ do_boot_menu() {
   fi
 }
 
+do_network_menu() {
+  FUN=$(whiptail --title "Raspberry Pi Software Configuration Tool (raspi-config)" --menu "Network Options" $WT_HEIGHT $WT_WIDTH $WT_MENU_HEIGHT --cancel-button Back --ok-button Select \
+    "N1 Hostname" "Set the visible name for this Pi on a network" \
+    "N2 Wi-fi" "Enter SSID and passphrase" \
+    "N3 Network interface names" "Enable/Disable predictable network interface names" \
+    3>&1 1>&2 2>&3)
+  RET=$?
+  if [ $RET -eq 1 ]; then
+    return 0
+  elif [ $RET -eq 0 ]; then
+    case "$FUN" in
+      N1\ *) do_hostname ;;
+      N2\ *) do_wifi_ssid_passphrase ;;
+      N3\ *) do_net_names ;;
+      *) whiptail --msgbox "Programmer error: unrecognized option" 20 60 1 ;;
+    esac || whiptail --msgbox "There was an error running option $FUN" 20 60 1
+  fi
+}
+
 #
 # Interactive use loop
 #
@@ -1578,7 +1676,7 @@ if [ "$INTERACTIVE" = True ]; then
 	if is_pi ; then
       FUN=$(whiptail --title "Raspberry Pi Software Configuration Tool (raspi-config)" --backtitle "$(cat /proc/device-tree/model)" --menu "Setup Options" $WT_HEIGHT $WT_WIDTH $WT_MENU_HEIGHT --cancel-button Finish --ok-button Select \
         "1 Change User Password" "Change password for the current user" \
-        "2 Hostname" "Set the visible name for this Pi on a network" \
+        "2 Network Options" "Configure network settings" \
         "3 Boot Options" "Configure options for start-up" \
         "4 Localisation Options" "Set up language and regional settings to match your location" \
         "5 Interfacing Options" "Configure connections to peripherals" \
@@ -1604,7 +1702,7 @@ if [ "$INTERACTIVE" = True ]; then
     elif [ $RET -eq 0 ]; then
       case "$FUN" in
         1\ *) do_change_pass ;;
-        2\ *) do_hostname ;;
+        2\ *) do_network_menu ;;
         3\ *) do_boot_menu ;;
         4\ *) do_internationalisation_menu ;;
         5\ *) do_interface_menu ;;


### PR DESCRIPTION
Replacing the top-level menu item `Hostname` is the new `Network Options`, which includes under it:
- Hostname
- Wi-fi SSID and passphrase
- Predictable network interface names

On entering the Wi-fi SSID option:

1. You are prompted for an **SSID**, then a **passphrase**. Passphrase may be left empty if not required.

2. On receiving the SSID and passphrase, the program tries to remove any existing network block belonging to that SSID (more on this below), before appending a network block to the file `/etc/wpa_supplicant/wpa_supplicant.conf`

    - If passphrase is empty, this block is inserted:
    ```
    network={
        ssid="..."
        key_mgmt=NONE
    }
    ```

    - Otherwise, the output of `wpa_passphrase ssid passphrase` is inserted.

3. Finally, if `wlan0` exists, `wpa_cli -i wlan0 reconfigure` is done.

In case anyone asks about WEP networks and hidden SSID, I am not going to provide them at this moment. This feature is intended to be a convenience that works for common situations. For unrestrained power, users are encouraged (to learn) to modify files by hand.

I do not reconfigure all wireless interfaces (in case of, for example, having a USB wifi dongle in addition to the onboard wifi adapter), because it is impossible to know the user's intention. Again, I only do the most common thing.

It's also worth noting that appending a network block does not necessarily make the machine connect to that SSID, because `wpa_supplicant.conf` may contain other SSIDs that are equally in range. It's up to the user to set priority in the network blocks.

Reliably removing an existing network block proves to be quite a challenge. It's hard to use `sed` to do non-trivial multi-line matching, so **I use `perl`** instead. Because an SSID may contain arbitrary characters, I have to escape special characters in the SSID before embedding it in the regex so it won't screw up the regex.