### PR TITLE
Add optional 2nd param to non-interactive do_serial to keep the UART enabled

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -863,7 +863,11 @@ do_serial() {
       whiptail --yesno "Would you like the serial port hardware to be enabled?" $DEFAULTH 20 60 2
       RET=$?
     else
-      RET=1
+      if [ $# -ge 2 ]; then
+        RET=$2
+      else
+        RET=1
+      fi
     fi
     if [ $RET -eq $CURRENTH ]; then
      ASK_TO_REBOOT=1


### PR DESCRIPTION
This makes it possible to disable the serial console without disabling the UART altogether:

    raspi-config nonint do_serial 1 0

If the first parameter is zero, the second one is ignored.

The second parameter defaults to 1, which means that if you don't supply it, raspi-config will behave as before.

As discussed in #29, even without this parameter it was possible to achieve the same result, but it required two calls:

    raspi-config nonint do_serial 1
    raspi-config nonint set_config_var enable_uart 1 /boot/config.txt