### PR TITLE
Don’t rely on $SUDO_USER being set

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -8,7 +8,9 @@ ASK_TO_REBOOT=0
 BLACKLIST=/etc/modprobe.d/raspi-blacklist.conf
 CONFIG=/boot/config.txt
 
-# Default to 'pi' if calling user cannot be determined.
+# If SUDO_USER is not set, retrieve the user who logged in on the current
+# terminal. If that cannot be determined, default to "pi".
+: ${SUDO_USER:=$(who -m | awk '{ print $1 }')}
 : ${SUDO_USER:=pi}
 
 is_pi () {

--- a/raspi-config
+++ b/raspi-config
@@ -8,6 +8,9 @@ ASK_TO_REBOOT=0
 BLACKLIST=/etc/modprobe.d/raspi-blacklist.conf
 CONFIG=/boot/config.txt
 
+# Default to 'pi' if calling user cannot be determined.
+: ${SUDO_USER:=pi}
+
 is_pi () {
   ARCH=$(dpkg --print-architecture)
   if [ "$ARCH" = "armhf" ] ; then


### PR DESCRIPTION
fa78a52 uses `$SUDO_USER` instead of the hardcoded name "pi" in places that refer to the default user on the system. This is good, as it allows you to rename it.

However, sometimes `$SUDO_USER` is not set, for example inside a shell started by `sudo su -`, which leads to commands doing nonsense or failing. Enabling auto login (mode B2) causes an invalid `agetty` command to be written, for example.

This commit fixes that problem by setting `$SUDO_USER` to `pi` when it is not defined as an environment variable. For users who have renamed their default user to something else _and_ call `raspi-config` from an environment without `$SUDO_USER`, this will of course be the wrong user, but at least the commands will be less nonsensical. And they can always override it by providing the name manually, like so:

    SUDO_USER=megan raspi-config