### PR TITLE
Update auto-login configuration to prevent $TERM substitution

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -970,7 +970,7 @@ do_boot_behaviour() {
         cat > /etc/systemd/system/getty@tty1.service.d/autologin.conf << EOF
 [Service]
 ExecStart=
-ExecStart=-/sbin/agetty --autologin $SUDO_USER --noclear %I $TERM
+ExecStart=-/sbin/agetty --autologin $SUDO_USER --noclear %I \$TERM
 EOF
         ;;
       B3*)
@@ -992,7 +992,7 @@ EOF
           cat > /etc/systemd/system/getty@tty1.service.d/autologin.conf << EOF
 [Service]
 ExecStart=
-ExecStart=-/sbin/agetty --autologin $SUDO_USER --noclear %I $TERM
+ExecStart=-/sbin/agetty --autologin $SUDO_USER --noclear %I \$TERM
 EOF
           sed /etc/lightdm/lightdm.conf -i -e "s/^\(#\|\)autologin-user=.*/autologin-user=$SUDO_USER/"
           disable_raspi_config_at_boot


### PR DESCRIPTION
Amend https://github.com/RPi-Distro/raspi-config/commit/d33487cbeac581d2ce91d8372f5feb1e2b5b7e3a#diff-abf7d6e1d74604f159aeaaf38a3f3b3aR962 to properly quote `$TERM` when the `autologin.conf` is created. 

  `$TERM` is set by the shell to the current terminal's value and the `autologin.conf` would automatically inherit with the invoking user's terminal settings. `TERM` would be incorrectly set for auto-login sessions.
 
  For instance, if `raspi-config` would be started from an _xterm_, when setting the auto-login to console the auto-login session would have `TERM` set to **xterm** instead of **linux**. 

Fixes #88 (_Auto-Login to console - incorrect TERM settings_).