### PR TITLE
Minor wording suggestion in `do_overclock`

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -573,7 +573,7 @@ set_memory_split() {
 
 do_overclock() {
   if ! is_pione && ! is_pitwo; then
-    whiptail --msgbox "This Pi cannot be overclocked." 20 60 2
+    whiptail --msgbox "Only Pi 1 or Pi 2 can be overclocked with this tool." 20 60 2
     return 1
   fi
   if [ "$INTERACTIVE" = True ]; then


### PR DESCRIPTION
I'm proposing this clarification to the `do_overclock` error message that appears when used on a Pi 3.

Hopefully this change will make it obvious that the tool doesn't support overclocking the Pi 3, rather than some bug or unknown problem preventing it.

Issue #92 