### PR TITLE
Avoid running parted twice on NOOBS image

### DIFF
--- a/init_resize.sh
+++ b/init_resize.sh
@@ -150,11 +150,11 @@ main () {
       FAIL_REASON="Extended partition resize failed"
       return 1
     fi
-  fi
-
-  if ! parted -m "$ROOT_DEV" u s resizepart "$ROOT_PART_NUM" "$TARGET_END"; then
-    FAIL_REASON="Root partition resize failed"
-    return 1
+  else
+    if ! parted -m "$ROOT_DEV" u s resizepart "$ROOT_PART_NUM" "$TARGET_END"; then
+      FAIL_REASON="Root partition resize failed"
+      return 1
+    fi
   fi
 
   partprobe "$ROOT_DEV"


### PR DESCRIPTION
Apologies if I've over looked something but when studying init_resize.sh to adapt a copy to my own requirements I noticed it appears that parted would be run twice on a noobs image, although running twice doesn't seem to be an issue AFAICT.