### PR TITLE
timezone -> time zone

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -2289,7 +2289,7 @@ fi
 do_internationalisation_menu() {
   FUN=$(whiptail --title "Raspberry Pi Software Configuration Tool (raspi-config)" --menu "Localisation Options" $WT_HEIGHT $WT_WIDTH $WT_MENU_HEIGHT --cancel-button Back --ok-button Select \
     "I1 Change Locale" "Set up language and regional settings to match your location" \
-    "I2 Change Timezone" "Set up timezone to match your location" \
+    "I2 Change Time Zone" "Set up time zone to match your location" \
     "I3 Change Keyboard Layout" "Set the keyboard layout to match your keyboard" \
     "I4 Change WLAN Country" "Set the legal channels used in your country" \
     3>&1 1>&2 2>&3)


### PR DESCRIPTION
Correct spelling: timezone -> time zone per lexicon.com/en and a quick google on the subject.