### PR TITLE
Use ROOT_DEV variable in parted call

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -132,7 +132,7 @@ get_can_expand() {
     exit
   fi
 
-  LAST_PART_NUM=$(parted "ROOT_DEV" -ms unit s p | tail -n 1 | cut -f 1 -d:)
+  LAST_PART_NUM=$(parted "$ROOT_DEV" -ms unit s p | tail -n 1 | cut -f 1 -d:)
   if [ "$LAST_PART_NUM" -ne "$PART_NUM" ]; then
     echo 1
     exit


### PR DESCRIPTION
...instead of the string ROOT_DEV, which seems to be a typo comparing the code to the `do_expand_rootfs` function.