### PR TITLE
Use whoami in lieu of who + awk script

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -8,7 +8,7 @@ ASK_TO_REBOOT=0
 BLACKLIST=/etc/modprobe.d/raspi-blacklist.conf
 CONFIG=/boot/config.txt
 
-USER=${SUDO_USER:-$(who -m | awk '{ print $1 }')}
+USER="${SUDO_USER:-$(whoami)}"
 
 is_pi () {
   ARCH=$(dpkg --print-architecture)


### PR DESCRIPTION
Rationale:

⋅ increased efficiency
⋅ succinctness
⋅ no additional dependencies
⋅ fixes fringe-case bug triggered when "who -m" outputs more than one user, e.g. as with "raspi-config nonint do_audio 1" bound to an Openbox menu item

Thank you.