### PR TITLE
Overlay: Add option for `/persistent` directory to survive reboots

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -2181,6 +2181,13 @@ local_mount_root()
 	mount -t overlay \
 	    -olowerdir=/lower,upperdir=/upper/data,workdir=/upper/work \
 	    overlay ${rootmnt}
+
+	# if /persistent exists, let it survive reboots
+	# NOTE: user must opt-in by creating /persistent BEFORE enabling overlay
+	if [ -e /lower/persistent ]; then
+		mount --bind /lower/persistent ${rootmnt}/persistent
+		mount -o remount,rw ${rootmnt}/persistent
+	fi
 }
 EOF
 


### PR DESCRIPTION
This adds an optional persistent directory that will survive reboots.

A user opts in by creating a `/persistent` directory before enabling the overlay.

During boot, if the `/persistent` directory exists, it will be mounted in read/write mode, making its content survive reboots.

*But why?*
Persist **some** data across reboots while still keeping 99.9% of the system read-only.

Anything written there will survive reboots, including via symlinks from the rest of the system.
(The symlinks should normally be created before enabling the overlay, otherwise they won't survive the reboot themselves.)

After enabling:
```sh
pi@raspberrypi:~ $ mount
overlay on / type overlay (rw,noatime,lowerdir=/lower,upperdir=/upper/data,workdir=/upper/work)
/dev/mmcblk0p2 on /persistent type ext4 (rw,relatime)
/dev/mmcblk0p1 on /boot type vfat (ro,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=ascii,shortname=mixed,errors=remount-ro)
...
```

Note: Only `/persistent` is available, not the entire root partition.