### PR TITLE
Remove invalid xcompmgr option

### DIFF
--- a/usr/lib/raspi-config/cmstart.sh
+++ b/usr/lib/raspi-config/cmstart.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 if grep -q okay /proc/device-tree/soc/v3d@7ec00000/status 2> /dev/null || grep -q okay /proc/device-tree/soc/firmwarekms@7e600000/status 2> /dev/null ; then
-    xcompmgr -aR
+    xcompmgr -a
 fi


### PR DESCRIPTION
"-R" is not a valid option for xcompmgr: https://manpages.debian.org/xcompmgr

It is assumed to be a mistake introduced with this commit, where "xcompmgr -a" was used directly from the desktop entry before: https://github.com/RPi-Distro/raspi-config/commit/28666b835823b214f5ee85c351537b7786b2219c