### PR TITLE
Fixing fan control issues - 'gpio_pin' parameter should be 'gpiopin', extending the allowed temperature range

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -1189,7 +1189,7 @@ get_fan() {
 get_fan_gpio() {
   GPIO=$(grep ^dtoverlay=gpio-fan $CONFIG | cut -d, -f2 | cut -d= -f2)
   if [ -z $GPIO ]; then
-    GPIO=12
+    GPIO=14
   fi
   echo $GPIO
 }
@@ -1197,7 +1197,7 @@ get_fan_gpio() {
 get_fan_temp() {
   TEMP=$(grep ^dtoverlay=gpio-fan $CONFIG | cut -d, -f3 | cut -d= -f2)
   if [ -z $TEMP ]; then
-    TEMP=55000
+    TEMP=80000
   fi
   echo $(( $TEMP / 1000 ))
 }
@@ -1240,7 +1240,7 @@ do_fan() {
       TIN=$(whiptail --inputbox "At what temperature in degrees should the fan turn on?" 20 60 "$TNOW" 3>&1 1>&2 2>&3)
     else
       if [ -z $3 ]; then
-        TIN=55
+        TIN=80
       else
         TIN=$3
       fi

--- a/raspi-config
+++ b/raspi-config
@@ -1189,7 +1189,7 @@ get_fan() {
 get_fan_gpio() {
   GPIO=$(grep ^dtoverlay=gpio-fan $CONFIG | cut -d, -f2 | cut -d= -f2)
   if [ -z $GPIO ]; then
-    GPIO=14
+    GPIO=12
   fi
   echo $GPIO
 }
@@ -1197,7 +1197,7 @@ get_fan_gpio() {
 get_fan_temp() {
   TEMP=$(grep ^dtoverlay=gpio-fan $CONFIG | cut -d, -f3 | cut -d= -f2)
   if [ -z $TEMP ]; then
-    TEMP=80000
+    TEMP=55000
   fi
   echo $(( $TEMP / 1000 ))
 }
@@ -1240,7 +1240,7 @@ do_fan() {
       TIN=$(whiptail --inputbox "At what temperature in degrees should the fan turn on?" 20 60 "$TNOW" 3>&1 1>&2 2>&3)
     else
       if [ -z $3 ]; then
-        TIN=80
+        TIN=55
       else
         TIN=$3
       fi
@@ -1250,13 +1250,13 @@ do_fan() {
     fi
     if ! echo "$TIN" | grep -q ^[[:digit:]]*$ ; then
       if [ "$INTERACTIVE" = True ]; then
-        whiptail --msgbox "Temperature must be a number between 60 and 120" 20 60 1
+        whiptail --msgbox "Temperature must be a number between 0 and 120" 20 60 1
       fi
       return 1
     fi
-    if [ "$TIN" -lt 60 ] || [ "$TIN" -gt 120 ]  ; then
+    if [ "$TIN" -lt 0 ] || [ "$TIN" -gt 120 ]  ; then
       if [ "$INTERACTIVE" = True ]; then
-        whiptail --msgbox "Temperature must be a number between 60 and 120" 20 60 1
+        whiptail --msgbox "Temperature must be a number between 0 and 120" 20 60 1
       fi
       return 1
     fi
@@ -1267,9 +1267,9 @@ do_fan() {
       if ! tail -1 $CONFIG | grep -q "\\[all\\]" ; then
         sed $CONFIG -i -e "\$a[all]"
       fi
-      sed $CONFIG -i -e "\$adtoverlay=gpio-fan,gpio_pin=$GPIO,temp=$TEMP"
+      sed $CONFIG -i -e "\$adtoverlay=gpio-fan,gpiopin=$GPIO,temp=$TEMP"
     else
-      sed $CONFIG -i -e "s/^.*dtoverlay=gpio-fan.*/dtoverlay=gpio-fan,gpio_pin=$GPIO,temp=$TEMP/"
+      sed $CONFIG -i -e "s/^.*dtoverlay=gpio-fan.*/dtoverlay=gpio-fan,gpiopin=$GPIO,temp=$TEMP/"
     fi
     ASK_TO_REBOOT=1
     if [ "$INTERACTIVE" = True ]; then


### PR DESCRIPTION
The 'gpiopin' fix addresses #138.

I also extended the temperature validation range since 60 degrees is relatively high and at least I would like to be able to keep my pi cooler than that. As a reference, the default temperature for this overlay is 55 degrees and the rpi-poe overlay by default starts its fan at 40 degrees and reaches full speed at 55 degrees (https://github.com/raspberrypi/firmware/tree/master/boot/overlays). This change will also allow someone to run the fan constantly by setting the temperature to, say 0 degrees.
Still, it looks like the temperature range validation needs to be updated in the Raspberry Pi Config GUI tools as well. So I can back this change out and open a new issue if needed.