### PR TITLE
cmstart.sh: exec xcompmgr

### DIFF
--- a/usr/lib/raspi-config/cmstart.sh
+++ b/usr/lib/raspi-config/cmstart.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 if grep -q okay /proc/device-tree/soc/v3d@7ec00000/status 2> /dev/null || grep -q okay /proc/device-tree/soc/firmwarekms@7e600000/status 2> /dev/null ; then
-    xcompmgr -aR
+    exec xcompmgr -aR
 fi


### PR DESCRIPTION
This will release resources used by `/bin/sh` process:

```

pi       24793  0.0  0.0   1940   404 ?        S    22:32   0:00 /bin/sh /usr/lib/raspi-config/cmstart.sh
pi       24799  0.0  0.0   4872  1044 ?        S    22:32   0:00  \_ xcompmgr -aR
```