### PR TITLE
Add debian/copyright file

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -1,0 +1,25 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Source: https://github.com/RPi-Distro/raspi-config
+
+Files: *
+Copyright: 2012 Alex Bradbury <asb@asbradbury.org>
+License: MIT
+
+License: MIT
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to
+ deal in the Software without restriction, including without limitation the
+ rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ sell copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.


### PR DESCRIPTION
The Debian Policy Manual says, that every package must be accompanied by a
verbatim copy of its distribution license(s)[1]. The missing copyright file
produces errors when tools try parse these information to check licenses.

Add a copyright file to the debian directory. It repruduces the content
of the LICENSE file in the root directory.

[1] https://www.debian.org/doc/debian-policy/ch-source.html#copyright-debian-copyright

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>