### PR TITLE
Filter wlan interfaces before using wpa_cli

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,7 +3,7 @@ raspi-config (20221108) bullseye; urgency=medium
   [ Jorge Capona ]
   * Filter wlan interfaces before using wpa_cli
 
- -- Serge Schneider <serge@raspberrypi.com>  Wed, 29 Jun 2022 15:24:31 +0100
+ -- Serge Schneider <serge@raspberrypi.com>  Tue, 08 Nov 2022 18:28:38 -0300
 
 raspi-config (20221018) bullseye; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+raspi-config (20220629) bullseye; urgency=medium
+
+  [ Jorge Capona ]
+  * Filter wlan interfaces before using wpa_cli
+
+ -- Serge Schneider <serge@raspberrypi.com>  Wed, 29 Jun 2022 15:24:31 +0100
+
 raspi-config (20220506) bullseye; urgency=medium
 
   * Modify Wayland switching to work with AccountSettings

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,3 @@
-raspi-config (20221108) bullseye; urgency=medium
-
-  [ Jorge Capona ]
-  * Filter wlan interfaces before using wpa_cli
-
- -- Serge Schneider <serge@raspberrypi.com>  Tue, 08 Nov 2022 18:28:38 -0300
-
 raspi-config (20221018) bullseye; urgency=medium
 
   * do_hostname: add fallback for cases when hostnamectl isn't suitable

--- a/raspi-config
+++ b/raspi-config
@@ -577,19 +577,11 @@ do_change_timezone() {
 
 get_wifi_country() {
   CODE=${1:-0}
-  IFACE="$(list_wlan_interfaces | head -n 1)"
+  IFACE="$(list_valid_wlan_interfaces | head -n 1)"
   if [ -z "$IFACE" ]; then
-    if [ "$INTERACTIVE" = True ]; then
-      whiptail --msgbox "No wireless interface found" 20 60
-    fi
     return 1
   fi
-  if ! wpa_cli -i "$IFACE" status > /dev/null 2>&1; then
-    if [ "$INTERACTIVE" = True ]; then
-      whiptail --msgbox "Could not communicate with wpa_supplicant" 20 60
-    fi
-    return 1
-  fi
+
   wpa_cli -i "$IFACE" save_config > /dev/null 2>&1
   COUNTRY="$(wpa_cli -i "$IFACE" get country)"
   if [ "$COUNTRY" = "FAIL" ]; then
@@ -602,18 +594,8 @@ get_wifi_country() {
 }
 
 do_wifi_country() {
-  IFACE="$(list_wlan_interfaces | head -n 1)"
+  IFACE="$(list_valid_wlan_interfaces | head -n 1)"
   if [ -z "$IFACE" ]; then
-    if [ "$INTERACTIVE" = True ]; then
-      whiptail --msgbox "No wireless interface found" 20 60
-    fi
-    return 1
-  fi
-
-  if ! wpa_cli -i "$IFACE" status > /dev/null 2>&1; then
-    if [ "$INTERACTIVE" = True ]; then
-      whiptail --msgbox "Could not communicate with wpa_supplicant" 20 60
-    fi
     return 1
   fi
 
@@ -2328,22 +2310,34 @@ list_wlan_interfaces() {
   done
 }
 
+list_valid_wlan_interfaces() {
+  IFACES="$(list_wlan_interfaces)"
+  VALID_IFACE_FOUND=""
+  ERROR_MESSAGE=""
+  if [ -z "$IFACES" ]; then
+    ERROR_MESSAGE="No wireless interface found"
+  fi
+
+  for IFACE in $IFACES; do
+    if ! wpa_cli -i "$IFACE" status > /dev/null 2>&1; then
+      ERROR_MESSAGE="Interface could not communicate with wpa_supplicant"
+      continue
+    fi
+    VALID_IFACE_FOUND=1
+    echo "$IFACE"
+  done
+
+  if [ -z "$VALID_IFACE_FOUND" ] && [ ! -z "$ERROR_MESSAGE" ] && [ "$INTERACTIVE" = True ]; then
+    whiptail --msgbox "${ERROR_MESSAGE}" 20 60
+  fi
+}
+
 do_wifi_ssid_passphrase() {
   RET=0
-  IFACE_LIST="$(list_wlan_interfaces)"
+  IFACE_LIST="$(list_valid_wlan_interfaces)"
   IFACE="$(echo "$IFACE_LIST" | head -n 1)"
 
   if [ -z "$IFACE" ]; then
-    if [ "$INTERACTIVE" = True ]; then
-      whiptail --msgbox "No wireless interface found" 20 60
-    fi
-    return 1
-  fi
-
-  if ! wpa_cli -i "$IFACE" status > /dev/null 2>&1; then
-    if [ "$INTERACTIVE" = True ]; then
-      whiptail --msgbox "Could not communicate with wpa_supplicant" 20 60
-    fi
     return 1
   fi
 

--- a/raspi-config
+++ b/raspi-config
@@ -2375,7 +2375,7 @@ list_wlan_interfaces() {
   for dir in /sys/class/net/*/wireless; do
     if [ -d "$dir" ]; then
       IFACE="$(basename "$(dirname "$dir")")"
-      if wpa_cli -i "$IFACE" status &> /dev/null; then
+      if wpa_cli -i "$IFACE" status > /dev/null 2>&1; then
         echo "$IFACE"
       fi
     fi

--- a/raspi-config
+++ b/raspi-config
@@ -2327,7 +2327,7 @@ list_valid_wlan_interfaces() {
     echo "$IFACE"
   done
 
-  if [ -z "$VALID_IFACE_FOUND" ] && [ ! -z "$ERROR_MESSAGE" ] && [ "$INTERACTIVE" = True ]; then
+  if [ -z "$VALID_IFACE_FOUND" ] && [ -n "$ERROR_MESSAGE" ] && [ "$INTERACTIVE" = True ]; then
     whiptail --msgbox "${ERROR_MESSAGE}" 20 60
   fi
 }

--- a/raspi-config
+++ b/raspi-config
@@ -2374,7 +2374,10 @@ EOF
 list_wlan_interfaces() {
   for dir in /sys/class/net/*/wireless; do
     if [ -d "$dir" ]; then
-      basename "$(dirname "$dir")"
+      IFACE="$(basename "$(dirname "$dir")")"
+      if wpa_cli -i "$IFACE" status &> /dev/null; then
+        echo "$IFACE"
+      fi
     fi
   done
 }


### PR DESCRIPTION
Closes #161 

The approach taken is to filter the list of wireless network interfaces to determine which ones are under control of `wpa_supplicant`, and use those in the functions that perform wlan operations.