### PR TITLE
Prevent showing error message after call do_about()

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -133,6 +133,7 @@ configuration of the Raspberry Pi. Although it can be run
 at any time, some of the options may have difficulties if
 you have heavily customised your installation.\
 " 20 70 1
+  return 0
 }
 
 get_can_expand() {


### PR DESCRIPTION
Hi, 

If select the 9th option `About raspi-config`, then I will get this

![image](https://user-images.githubusercontent.com/20593333/123425212-6d743180-d5f4-11eb-9770-0cac7682eb33.png)

and if I press `ESC`, I will get this error message, I think it should be a normal behaviour for pressing `ESC` to return to previous menu.
![image](https://user-images.githubusercontent.com/20593333/123425295-90064a80-d5f4-11eb-9625-bb554039124e.png)
