### PR TITLE
fix(do_overlayfs): msgbox in non-interactve mode

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -2465,7 +2465,11 @@ do_overlayfs() {
     else
       BPRO="writable"
     fi
-    whiptail --msgbox "The boot partition is currently $BPRO. This cannot be changed while an overlay file system is enabled." 20 60 1
+    if [ "$INTERACTIVE" = True ]; then
+      whiptail --msgbox "The boot partition is currently $BPRO. This cannot be changed while an overlay file system is enabled." 20 60 1
+    else
+      echo "The boot partition is currently $BPRO. This cannot be changed while an overlay file system is enabled."
+    fi
   else
     DEFAULT=--defaultno
     CURRENT=0


### PR DESCRIPTION
Adds missing check before MessageBox (about inability to change the parameters of the boot partition) for non-interactive mode.
Without it, commands like `raspi-config nonint do_overlayfs 1`, get stuck with whiptail MessageBox when running under systems with enabled overlayfs.