### PR TITLE
Correct composite/4Kp60 menu option on Pi 4

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -2854,23 +2854,27 @@ do_system_menu() {
 
 do_display_menu() {
   if is_pi ; then
-    if is_fkms; then
-    FUN=$(whiptail --title "Raspberry Pi Software Configuration Tool (raspi-config)" --menu "Display Options" $WT_HEIGHT $WT_WIDTH $WT_MENU_HEIGHT --cancel-button Back --ok-button Select \
-      "D2 Underscan" "Remove black border around screen" \
-      "D3 Pixel Doubling" "Enable/disable 2x2 pixel mapping" \
-      "D4 Screen Blanking" "Enable/disable screen blanking" \
-      "D5 VNC Resolution" "Set resolution for headless use" \
-      "D6 Composite" "Set options for composite output" \
-      3>&1 1>&2 2>&3)
+    set -- "D1 Resolution" "Set a specific screen resolution" "D2 Underscan" "Remove black border around screen" "D3 Pixel Doubling" "Enable/disable 2x2 pixel mapping" "D4 Screen Blanking" "Enable/disable screen blanking" "D5 VNC Resolution" "Set resolution for headless use" "D6 Composite" "Set options for composite output";
+    if is_pifour; then
+      if is_fkms; then
+      FUN=$(whiptail --title "Raspberry Pi Software Configuration Tool (raspi-config)" --menu "Display Options" $WT_HEIGHT $WT_WIDTH $WT_MENU_HEIGHT --cancel-button Back --ok-button Select \
+        "$3" "$4" "$5" "$6" "$7" "$8" "$9" "${10}" "D6 Composite/4Kp60" "Composite and 4kp60 options" \
+        3>&1 1>&2 2>&3)
+      else
+      FUN=$(whiptail --title "Raspberry Pi Software Configuration Tool (raspi-config)" --menu "Display Options" $WT_HEIGHT $WT_WIDTH $WT_MENU_HEIGHT --cancel-button Back --ok-button Select \
+        "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9" "${10}" "D6 Composite/4Kp60" "Composite and 4Kp60 options" \
+        3>&1 1>&2 2>&3)
+      fi
     else
-    FUN=$(whiptail --title "Raspberry Pi Software Configuration Tool (raspi-config)" --menu "Display Options" $WT_HEIGHT $WT_WIDTH $WT_MENU_HEIGHT --cancel-button Back --ok-button Select \
-      "D1 Resolution" "Set a specific screen resolution" \
-      "D2 Underscan" "Remove black border around screen" \
-      "D3 Pixel Doubling" "Enable/disable 2x2 pixel mapping" \
-      "D4 Screen Blanking" "Enable/disable screen blanking" \
-      "D5 VNC Resolution" "Set resolution for headless use" \
-      "D6 Composite" "Set options for composite output" \
-      3>&1 1>&2 2>&3)
+      if is_fkms; then
+      FUN=$(whiptail --title "Raspberry Pi Software Configuration Tool (raspi-config)" --menu "Display Options" $WT_HEIGHT $WT_WIDTH $WT_MENU_HEIGHT --cancel-button Back --ok-button Select \
+        "$3" "$4" "$5" "$6" "$7" "$8" "$9" "${10}" "${11}" "${12}" \
+        3>&1 1>&2 2>&3)
+      else
+      FUN=$(whiptail --title "Raspberry Pi Software Configuration Tool (raspi-config)" --menu "Display Options" $WT_HEIGHT $WT_WIDTH $WT_MENU_HEIGHT --cancel-button Back --ok-button Select \
+        "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9" "${10}" "${11}" "${12}" \
+        3>&1 1>&2 2>&3)
+      fi
     fi
   else
     FUN=$(whiptail --title "Raspberry Pi Software Configuration Tool (raspi-config)" --menu "Display Options" $WT_HEIGHT $WT_WIDTH $WT_MENU_HEIGHT --cancel-button Back --ok-button Select \


### PR DESCRIPTION
Some explanation is required for this one, since it alters the flow of the script more than would appear necessary:

raspi-config uses /bin/sh, which on Debian means dash by default, not bash. As such, there is no support for arrays, since dash follows POSIX and there are no arrays in POSIX-only shells. Arrays are needed because otherwise I would need to create more duplication in the `display` menu code. At present, there are two places which define what the `display` menu looks like - one for the KMS case including FKMS, and one for the legacy graphics stack. In order to add `/4Kp60` to the existing `D6 Composite` menu item for only Pi 4, I would have needed to duplicate both of these options, which would mean having four slightly different versions of the `display` menu defined in the script. So instead I use the fact that POSIX shells do support one array - the positional arguments. The menu items are defined once, and each of the four variations of the display menu selects different array elements.

The alternative would have been to simply switch raspi-config to using bash, but I decided this would probably not be welcome.

I have tested all four cases - Pi 4 with KMS, Pi 4 with legacy graphics, non-Pi 4 (on a Pi 3B+) with KMS, non Pi 4 (on a Pi 3B+) with legacy graphics.