### PR TITLE
Correct wording on EEPROM menu options

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -1538,9 +1538,9 @@ do_boot_order() {
 
 do_boot_rom() {
   if [ "$INTERACTIVE" = True ]; then
-    BOOTOPT=$(whiptail --title "Raspberry Pi Software Configuration Tool (raspi-config)" --menu "Boot ROM Options" $WT_HEIGHT $WT_WIDTH $WT_MENU_HEIGHT \
-      "E1 Latest" "Use the latest version boot ROM software" \
-      "E2 Default" "Use the factory default boot ROM software" \
+    BOOTOPT=$(whiptail --title "Raspberry Pi Software Configuration Tool (raspi-config)" --menu "Bootloader EEPROM Options" $WT_HEIGHT $WT_WIDTH $WT_MENU_HEIGHT \
+      "E1 Latest" "Use latest bootloader EEPROM software" \
+      "E2 Default" "Use default bootloader EEPROM software" \
       3>&1 1>&2 2>&3)
   else
     BOOTOPT=$1
@@ -1557,12 +1557,12 @@ do_boot_rom() {
         EETYPE="Factory default"
         ;;
       *)
-        whiptail --msgbox "Programmer error, unrecognised boot ROM option" 20 60 2
+        whiptail --msgbox "Programmer error, unrecognised bootloader EEPROM option" 20 60 2
         return 1
         ;;
     esac
     if [ "$INTERACTIVE" = True ]; then
-      whiptail --yesno "$EETYPE boot ROM selected - will be loaded at next reboot.\n\nReset boot ROM to defaults?" 20 60 2
+      whiptail --yesno "$EETYPE bootloader EEPROM selected - will be installed at next reboot.\n\nReset bootloader EEPROM config to defaults?" 20 60 2
       DEFAULTS=$?
     else
       DEFAULTS=$2
@@ -1582,13 +1582,13 @@ do_boot_rom() {
       else
         rpi-eeprom-update -d -f $FILNAME
         if [ "$INTERACTIVE" = True ]; then
-          whiptail --msgbox "Boot ROM reset to defaults" 20 60 2
+          whiptail --msgbox "Bootloader EEPROM config reset to defaults" 20 60 2
         fi
       fi
     else
       rpi-eeprom-update
       if [ "$INTERACTIVE" = True ]; then
-        whiptail --msgbox "Boot ROM not reset to defaults" 20 60 2
+        whiptail --msgbox "Boot EEPROM config left unchanged" 20 60 2
       fi
     fi
     ASK_TO_REBOOT=1
@@ -3043,7 +3043,7 @@ do_advanced_menu() {
       "A4 Network Interface Names" "Enable/disable predictable network i/f names" \
       "A5 Network Proxy Settings" "Configure network proxy settings" \
       "A6 Boot Order" "Choose network or USB device boot" \
-      "A7 Bootloader Version" "Select latest or default boot ROM software" \
+      "A7 Bootloader Version" "Select bootloader EEPROM software" \
       3>&1 1>&2 2>&3)
   elif is_pi ; then
     FUN=$(whiptail --title "Raspberry Pi Software Configuration Tool (raspi-config)" --menu "Advanced Options" $WT_HEIGHT $WT_WIDTH $WT_MENU_HEIGHT --cancel-button Back --ok-button Select \

--- a/raspi-config
+++ b/raspi-config
@@ -1588,7 +1588,7 @@ do_boot_rom() {
     else
       rpi-eeprom-update
       if [ "$INTERACTIVE" = True ]; then
-        whiptail --msgbox "Boot EEPROM config left unchanged" 20 60 2
+        whiptail --msgbox "Bootloader EEPROM config left unchanged" 20 60 2
       fi
     fi
     ASK_TO_REBOOT=1

--- a/raspi-config
+++ b/raspi-config
@@ -1540,7 +1540,7 @@ do_boot_rom() {
   if [ "$INTERACTIVE" = True ]; then
     BOOTOPT=$(whiptail --title "Raspberry Pi Software Configuration Tool (raspi-config)" --menu "Bootloader EEPROM Options" $WT_HEIGHT $WT_WIDTH $WT_MENU_HEIGHT \
       "E1 Latest" "Use latest bootloader EEPROM software" \
-      "E2 Default" "Use default bootloader EEPROM software" \
+      "E2 Default" "Use factory default bootloader EEPROM software" \
       3>&1 1>&2 2>&3)
   else
     BOOTOPT=$1


### PR DESCRIPTION
The following corrections are included:

1. Use `bootloader EEPROM` instead of `boot ROM` so raspi-config uses terminology that is consistent with documentation.
2. Don't refer to using default EEPROM image as a factory reset - it isn't - it just loads the image from the default branch, which may or may not be the same as the image which that Pi shipped with (currently, it won't be the same image).
3. Make it clear that 'reset to defaults' option which the user is prompted for refers to resetting the bootloader EEPROM _**config**_ to defaults, rather than the EEPROM image itself.
4. Clarify wording in case where user chooses not the reset EEPROM config to defaults.

I have tested these changes on a Pi 4B and Pi 3B and the menus continue to function as intended on both.