### PR TITLE
do_hostname should error propogate errors

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -637,6 +637,7 @@ get_hostname() {
 }
 
 do_hostname() {
+  set -e
   if [ "$INTERACTIVE" = True ]; then
     whiptail --msgbox "\
 Please note: RFCs mandate that a hostname's labels \


### PR DESCRIPTION
A way to help with #113 unless the solution is to move the root check to before the nonint switch