### PR TITLE
Make boot mount-point configurable

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -6,7 +6,8 @@
 INTERACTIVE=True
 ASK_TO_REBOOT=0
 BLACKLIST=/etc/modprobe.d/raspi-blacklist.conf
-CONFIG=/boot/config.txt
+BOOT="/boot"
+CONFIG="$BOOT"/config.txt
 
 USER=${SUDO_USER:-$(who -m | awk '{ print $1 }')}
 
@@ -20,7 +21,7 @@ is_pi () {
 }
 
 if is_pi ; then
-  CMDLINE=/boot/cmdline.txt
+  CMDLINE="$BOOT"/cmdline.txt
 else
   CMDLINE=/proc/cmdline
 fi
@@ -676,7 +677,7 @@ No other symbols, punctuation characters, or blank spaces are permitted.\
 }
 
 do_memory_split() { # Memory Split
-  if [ -e /boot/start_cd.elf ]; then
+  if [ -e "$BOOT"/start_cd.elf ]; then
     # New-style memory split setting
     ## get current memory split from /boot/config.txt
     arm=$(vcgencmd get_mem arm | cut -d '=' -f 2 | cut -d 'M' -f 1)
@@ -732,7 +733,7 @@ get_current_memory_split() {
   AVAILABLE_SPLITS="128 192 224 240"
   MEMSPLIT_DESCRIPTION=""
   for SPLIT in $AVAILABLE_SPLITS;do
-    if [ -e /boot/arm${SPLIT}_start.elf ] && cmp /boot/arm${SPLIT}_start.elf /boot/start.elf >/dev/null 2>&1;then
+    if [ -e "$BOOT"/arm${SPLIT}_start.elf ] && cmp "$BOOT"/arm${SPLIT}_start.elf "$BOOT"/start.elf >/dev/null 2>&1;then
       CURRENT_MEMSPLIT=$SPLIT
       MEMSPLIT_DESCRIPTION="Current: ${CURRENT_MEMSPLIT}MiB for ARM, $((256 - $CURRENT_MEMSPLIT))MiB for VideoCore"
       break
@@ -741,7 +742,7 @@ get_current_memory_split() {
 }
 
 set_memory_split() {
-  cp -a /boot/arm${1}_start.elf /boot/start.elf
+  cp -a "$BOOT"/arm${1}_start.elf "$BOOT"/start.elf
   sync
 }
 
@@ -1758,7 +1759,7 @@ get_camera() {
 }
 
 do_camera() {
-  if [ $(deb_ver) -le 10 ] && [ ! -e /boot/start_x.elf ]; then
+  if [ $(deb_ver) -le 10 ] && [ ! -e "$BOOT"/start_x.elf ]; then
     whiptail --msgbox "Your firmware appears to be out of date (no start_x.elf). Please update" 20 60 2
     return 1
   fi
@@ -1910,7 +1911,7 @@ do_legacy() {
 }
 
 do_gldriver() {
-  if [ ! -e /boot/overlays/vc4-kms-v3d.dtbo ]; then
+  if [ ! -e "$BOOT"/overlays/vc4-kms-v3d.dtbo ]; then
     whiptail --msgbox "Driver and kernel not present on your system. Please update" 20 60 2
     return 1
   fi
@@ -2443,10 +2444,10 @@ get_json_string_val() {
 
 # TODO: This is probably broken
 do_apply_os_config() {
-  [ -e /boot/os_config.json ] || return 0
-  NOOBSFLAVOUR=$(get_json_string_val /boot/os_config.json flavour)
-  NOOBSLANGUAGE=$(get_json_string_val /boot/os_config.json language)
-  NOOBSKEYBOARD=$(get_json_string_val /boot/os_config.json keyboard)
+  [ -e "$BOOT"/os_config.json ] || return 0
+  NOOBSFLAVOUR=$(get_json_string_val "$BOOT"/os_config.json flavour)
+  NOOBSLANGUAGE=$(get_json_string_val "$BOOT"/os_config.json language)
+  NOOBSKEYBOARD=$(get_json_string_val "$BOOT"/os_config.json keyboard)
 
   if [ -n "$NOOBSFLAVOUR" ]; then
     printf "Setting flavour to %s based on os_config.json from NOOBS. May take a while\n" "$NOOBSFLAVOUR"
@@ -2514,17 +2515,17 @@ get_overlay_now() {
 }
 
 get_overlay_conf() {
-  grep -q "boot=overlay" /boot/cmdline.txt
+  grep -q "boot=overlay" "$BOOT"/cmdline.txt
   echo $?
 }
 
 get_bootro_now() {
-  findmnt /boot | grep -q " ro,"
+  findmnt "$BOOT" | grep -q " ro,"
   echo $?
 }
 
 get_bootro_conf() {
-  grep /boot /etc/fstab | grep -q "defaults.*,ro[ ,]"
+  grep "$BOOT" /etc/fstab | grep -q "defaults.*,ro[ ,]"
   echo $?
 }
 
@@ -2538,7 +2539,7 @@ enable_overlayfs() {
 
   # mount the boot partition as writable if it isn't already
   if [ $(get_bootro_now) -eq 0 ] ; then
-    if ! mount -o remount,rw /boot 2>/dev/null ; then
+    if ! mount -o remount,rw "$BOOT" 2>/dev/null ; then
       echo "Unable to mount boot partition as writable - cannot enable"
       return 1
     fi
@@ -2611,21 +2612,21 @@ EOF
   update-initramfs -c -k "$KERN"
 
   # rename it so we know it has overlay added
-  mv /boot/initrd.img-"$KERN" /boot/"$INITRD"
+  mv /boot/initrd.img-"$KERN" "$BOOT"/"$INITRD"
 
   # there is now a modified initramfs ready for use...
 
   # modify config.txt
-  sed -i /boot/config.txt -e "/initramfs.*/d" 
-  echo initramfs "$INITRD" >> /boot/config.txt
+  sed -i "$BOOT"/config.txt -e "/initramfs.*/d" 
+  echo initramfs "$INITRD" >> "$BOOT"/config.txt
 
   # modify command line
-  if ! grep -q "boot=overlay" /boot/cmdline.txt ; then
-    sed -i /boot/cmdline.txt -e "s/^/boot=overlay /"
+  if ! grep -q "boot=overlay" "$BOOT"/cmdline.txt ; then
+    sed -i "$BOOT"/cmdline.txt -e "s/^/boot=overlay /"
   fi
 
   if [ "$BOOTRO" = "yes" ] ; then
-    if ! mount -o remount,ro /boot 2>/dev/null ; then
+    if ! mount -o remount,ro "$BOOT" 2>/dev/null ; then
       echo "Unable to remount boot partition as read-only"
     fi
   fi
@@ -2635,7 +2636,7 @@ disable_overlayfs() {
   KERN=$(uname -r)
   # mount the boot partition as writable if it isn't already
   if [ $(get_bootro_now) -eq 0 ] ; then
-    if ! mount -o remount,rw /boot 2>/dev/null ; then
+    if ! mount -o remount,rw "$BOOT" 2>/dev/null ; then
       echo "Unable to mount boot partition as writable - cannot disable"
       return 1
     fi
@@ -2645,14 +2646,14 @@ disable_overlayfs() {
   fi
 
   # modify config.txt
-  sed -i /boot/config.txt -e "/initramfs.*/d"
+  sed -i "$BOOT"/config.txt -e "/initramfs.*/d"
   update-initramfs -d -k "${KERN}-overlay"
 
   # modify command line
-  sed -i /boot/cmdline.txt -e "s/\(.*\)boot=overlay \(.*\)/\1\2/"
+  sed -i "$BOOT"/cmdline.txt -e "s/\(.*\)boot=overlay \(.*\)/\1\2/"
 
   if [ "$BOOTRO" = "yes" ] ; then
-    if ! mount -o remount,ro /boot 2>/dev/null ; then
+    if ! mount -o remount,ro "$BOOT" 2>/dev/null ; then
       echo "Unable to remount boot partition as read-only"
     fi
   fi
@@ -2663,7 +2664,7 @@ enable_bootro() {
     echo "Overlay in use; cannot update fstab"
     return 1
   fi
-  sed -i /etc/fstab -e "s/\(.*\/boot.*\)defaults\(.*\)/\1defaults,ro\2/"
+  sed -i /etc/fstab -e "s@\(.*$BOOT.*\)defaults\(.*\)@\1defaults,ro\2@"
 }
 
 disable_bootro() {
@@ -2671,7 +2672,7 @@ disable_bootro() {
     echo "Overlay in use; cannot update fstab"
     return 1
   fi
-  sed -i /etc/fstab -e "s/\(.*\/boot.*\)defaults,ro\(.*\)/\1defaults\2/"
+  sed -i /etc/fstab -e "s@\(.*$BOOT.*\)defaults,ro\(.*\)@\1defaults\2@"
 }
 
 do_overlayfs() {


### PR DESCRIPTION
On RaspiOS (and many derivatives) the boot mount-point is always /boot.
However on Ubuntu (and Debian), it is /boot/firmware (/boot is still the
target for kernel installation and initramfs generation, but
flash-kernel then copies files from there to /boot/firmware). This patch
changes references to /boot to $BOOT to make it easier to configure the
boot mount-point.

Please note that in the overlayfs routines, the location of the
generated initramfs is deliberately left as /boot (as this is always
correct even when the boot partition is *not* mounted there).