### PR TITLE
Make init_resize.sh work on a btrfs root partition

### DIFF
--- a/usr/lib/raspi-config/init_resize.sh
+++ b/usr/lib/raspi-config/init_resize.sh
@@ -41,13 +41,13 @@ check_noobs () {
 }
 
 get_variables () {
-  ROOT_PART_DEV=$(findmnt / -o source -n)
+  ROOT_PART_DEV=$(findmnt / -o source -nv)
   ROOT_PART_NAME=$(echo "$ROOT_PART_DEV" | cut -d "/" -f 3)
   ROOT_DEV_NAME=$(echo /sys/block/*/"${ROOT_PART_NAME}" | cut -d "/" -f 4)
   ROOT_DEV="/dev/${ROOT_DEV_NAME}"
   ROOT_PART_NUM=$(cat "/sys/block/${ROOT_DEV_NAME}/${ROOT_PART_NAME}/partition")
 
-  BOOT_PART_DEV=$(findmnt /boot -o source -n)
+  BOOT_PART_DEV=$(findmnt /boot -o source -nv)
   BOOT_PART_NAME=$(echo "$BOOT_PART_DEV" | cut -d "/" -f 3)
   BOOT_DEV_NAME=$(echo /sys/block/*/"${BOOT_PART_NAME}" | cut -d "/" -f 4)
   BOOT_PART_NUM=$(cat "/sys/block/${BOOT_DEV_NAME}/${BOOT_PART_NAME}/partition")

--- a/usr/lib/raspi-config/init_resize.sh
+++ b/usr/lib/raspi-config/init_resize.sh
@@ -167,7 +167,7 @@ main () {
     fi
   fi
 
-  if ! parted -m "$ROOT_DEV" u s resizepart "$ROOT_PART_NUM" "$TARGET_END"; then
+  if ! printf "resizepart %s\nyes\n%ss\n" "$ROOT_PART_NUM" "$TARGET_END" | parted "$ROOT_DEV" ---pretend-input-tty; then
     FAIL_REASON="Root partition resize failed"
     return 1
   fi


### PR DESCRIPTION
I maintain a small fork of pi-gen that creates images that use btrfs instead of ext4. In getting that working, I encountered a couple of gotchas in `init_resize.sh` that I'd like to fix upstream.

Note that `init_resize.sh` doesn't operate on filesystems, just partitions. The words ext4 and btrfs don't appear in it.