### PR TITLE
Add optional second argument to `do_overlayfs` to make separate control easier

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -2814,7 +2814,7 @@ do_overlayfs() {
       whiptail --yesno "Would you like the boot partition to be write-protected?" $DEFAULT 20 60 2
       RET=$?
     else
-      RET=$1
+      RET=${2:-$1}
     fi
     if [ $RET -eq $CURRENT ]; then
       if [ $RET -eq 0 ]; then


### PR DESCRIPTION
I've been using `raspi-config` with the `nonint` option in some scripts.

I noticed with `sudo raspi-config nonint do_overlayfs *` it is not possible to control the state of the boot fs independently of the root fs, assuming you have rw permissions already.

I think the problem is here

https://github.com/RPi-Distro/raspi-config/blob/0fc1f9552fc99332d57e3b6df20c64576466913a/raspi-config#L2817

Where `RET` is set to the first argument to the function (`$1`).

I think it would be a little better if it were to use a second argument that defaults to the same as the first: `${2:-$1}`.

Alternatively a `shift` after the previous ret assignment could work, but I think that would confuse things more than help.
