### PR TITLE
Stop do_update from entering interactive mode

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -2166,10 +2166,12 @@ do_net_names () {
 
 do_update() {
   apt-get update &&
-  apt-get install raspi-config &&
-  printf "Sleeping 5 seconds before reloading raspi-config\n" &&
-  sleep 5 &&
-  exec raspi-config
+  apt-get install raspi-config
+  if [ "$INTERACTIVE" = True ]; then
+    printf "Sleeping 5 seconds before reloading raspi-config\n" &&
+    sleep 5 &&
+    exec raspi-config
+   fi
 }
 
 do_audio() {

--- a/raspi-config
+++ b/raspi-config
@@ -2166,7 +2166,7 @@ do_net_names () {
 
 do_update() {
   apt-get update &&
-  apt-get install raspi-config
+  apt-get install raspi-config &&
   if [ "$INTERACTIVE" = True ]; then
     printf "Sleeping 5 seconds before reloading raspi-config\n" &&
     sleep 5 &&


### PR DESCRIPTION
When running in non-interactive mode, prevent do_update from entering interactive mode on completion.

This is in response to issue #213 
