### PR TITLE
Reverting do_serial interactive changes

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -1184,8 +1184,12 @@ do_serial() {
     DEFAULTH=
     CURRENTH=1
   fi
-  whiptail --yesno "Would you like a login shell to be accessible over serial?" $DEFAULTS 20 60 2
-  RET=$?
+  if [ "$INTERACTIVE" = True ]; then
+    whiptail --yesno "Would you like a login shell to be accessible over serial?" $DEFAULTS 20 60 2
+    RET=$?
+  else
+    RET=$1
+  fi
   if [ $RET -eq $CURRENTS ]; then
     ASK_TO_REBOOT=1
   fi
@@ -1197,8 +1201,12 @@ do_serial() {
   elif [ $RET -eq 1 ]; then
     do_serial_cons 1
     SSTATUS=disabled
-    whiptail --yesno "Would you like the serial port hardware to be enabled?" $DEFAULTH 20 60 2
-    RET=$?
+    if [ "$INTERACTIVE" = True ]; then
+      whiptail --yesno "Would you like the serial port hardware to be enabled?" $DEFAULTH 20 60 2
+      RET=$?
+    else
+      RET=$((2 - RET))
+    fi
     if [ $RET -eq $CURRENTH ]; then
       ASK_TO_REBOOT=1
     fi
@@ -1214,7 +1222,9 @@ do_serial() {
   else
     return $RET
   fi
-  whiptail --msgbox "The serial login shell is $SSTATUS\nThe serial interface is $HSTATUS" 20 60 1
+  if [ "$INTERACTIVE" = True ]; then
+    whiptail --msgbox "The serial login shell is $SSTATUS\nThe serial interface is $HSTATUS" 20 60 1
+  fi
 }
 
 do_serial_pi5() {


### PR DESCRIPTION
Interactive if statements were removed in a recent change - this adds them back in so nonint runs don't get prompted with whiptail.

These were removed in https://github.com/RPi-Distro/raspi-config/commit/a5bd201044510a208ac481829fd4dd18f915ad47#diff-3840729c184b09759334e4011cf6834fab101e0bc3534f8989dd135f81e6d53eL1187-L1192