### PR TITLE
Use wayvnc system service

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -939,6 +939,9 @@ do_vnc() {
   fi
   if [ $RET -eq 0 ]; then
     if is_installed wayvnc; then
+      systemctl stop wayvnc.service
+
+      # In case wayvnc is already running via older xdg-autostart machanism
       pkill wayvnc
       if [ -e /etc/xdg/autostart/wayvnc.desktop ] ; then
         rm /etc/xdg/autostart/wayvnc.desktop
@@ -949,51 +952,9 @@ do_vnc() {
       systemctl stop vncserver-x11-serviced.service
     fi
     if is_wayfire; then
-      mkdir -p $HOMEDIR/.config/wayvnc/
-      if ! [ -e $HOMEDIR/.config/wayvnc/config ] ; then
-        cat << EOF > $HOMEDIR/.config/wayvnc/config
-use_relative_paths=true
-address=0.0.0.0
-enable_auth=true
-enable_pam=true
-private_key_file=key.pem
-certificate_file=cert.pem
-rsa_private_key_file=rsa_key.pem
-EOF
-        chown -R $USER:$USER $HOMEDIR/.config/wayvnc/config
-      fi
-      if ! [ -e $HOMEDIR/.config/wayvnc/key.pem ] || ! [ -e $HOMEDIR/.config/wayvnc/cert.pem ] ; then
-        echo "Generating key..."
-        HOSTNAME=$(cat /etc/hostname)
-        IP=$(ifconfig | grep inet | head -n 1 | cut -d ' ' -f 10)
-        openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout $HOMEDIR/.config/wayvnc/key.pem -out $HOMEDIR/.config/wayvnc/cert.pem -subj /CN=$HOSTNAME -addext subjectAltName=DNS:$HOSTNAME,DNS:$HOSTNAME,IP:$IP 2> /dev/null
-        chown -R $USER:$USER $HOMEDIR/.config/wayvnc/*.pem
-        echo "Done"
-      fi
-      if ! [ -e $HOMEDIR/.config/wayvnc/rsa_key.pem ] ; then
-        echo "Generating RSA key..."
-        ssh-keygen -m pem -f $HOMEDIR/.config/wayvnc/rsa_key.pem -t rsa -N "" > /dev/null
-        chown -R $USER:$USER $HOMEDIR/.config/wayvnc/rsa_key.pem
-        echo "Done"
-      fi
-      if is_installed wayvnc || apt-get install "$APT_GET_FLAGS" wayvnc; then
-        KBL=$(grep XKBLAYOUT /etc/default/keyboard | cut -d \" -f 2)
-        KBV=$(grep XKBVARIANT /etc/default/keyboard | cut -d \" -f 2)
-        if [ -z $KBV ] ; then
-          VNCKBD="$KBL"
-        else
-          VNCKBD="$KBL-$KBV"
-        fi
-        cat << EOF > /etc/xdg/autostart/wayvnc.desktop
-[Desktop Entry]
-Type=Application
-Name=wayvnc
-Comment=Start wayvnc
-NoDisplay=true
-Exec=/usr/bin/wayvnc --render-cursor --keyboard=$VNCKBD
-OnlyShowIn=wayfire
-EOF
-        sudo -u $USER XDG_RUNTIME_DIR=/run/user/$SUDO_UID WAYLAND_DISPLAY=wayland-1 wayvnc --render-cursor --keyboard=$VNCKBD 2> /dev/null &
+      if is_installed wayvnc; then
+        systemctl enable wayvnc.service &&
+        systemctl start wayvnc.service &&
         STATUS=enabled
       else
         return 1
@@ -1009,19 +970,12 @@ EOF
     fi
   elif [ $RET -eq 1 ]; then
     if is_installed wayvnc; then
-      pkill wayvnc
-      if [ -e /etc/xdg/autostart/wayvnc.desktop ] ; then
-        rm /etc/xdg/autostart/wayvnc.desktop
-      fi
+      systemctl disable wayvnc.service
+      systemctl stop wayvnc.service
     fi
     if is_installed realvnc-vnc-server; then
       systemctl disable vncserver-x11-serviced.service
       systemctl stop vncserver-x11-serviced.service
-    fi
-    if is_wayfire; then
-      if [ -e $HOMEDIR/.config/wayvnc/config ] ; then
-        rm $HOMEDIR/.config/wayvnc/config
-      fi
     fi
     STATUS=disabled
   else


### PR DESCRIPTION
This turns wayvnc into a system service provided by the wayvnc-control package.

* `wayvnc-control.py` automatically finds the active wayland session and attaches wayvnc to it.
* Key generation is now handled in the `wayvnc-generate-keys.service` systemd service. It is only triggered if the keys are missing
* The config file resides in `/etc/wayvnc/config` and it is installed by the wayvnc-control package. 
* The `wayvnc.service` starts wayvnc via the `wayvnc-run.sh` shell script which sets the correct arguments for keyboard layout and calls `systemd-notify` when the control socket is ready.

This requires
 * wayvnc v0.8-rc0. A branch with a `debian` directory can be found here: https://github.com/any1/wayvnc/tree/pios
 * wayvnc-control: https://github.com/any1/rpi-wayvnc-control/

I'm not sure what's the best way to make sure that these changes remain in sync with the wayvnc and wayvnc-control packages, but you probably know how you want to do it?

This package could be made to depend on `wayvnc-control`, but perhaps that would be too strong a requirement?

This solves: https://github.com/raspberrypi/bookworm-feedback/issues/108 https://github.com/raspberrypi/bookworm-feedback/issues/61 and https://github.com/raspberrypi/bookworm-feedback/issues/42