### PR TITLE
Use wayvnc system service, take two

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -939,6 +939,9 @@ do_vnc() {
   fi
   if [ $RET -eq 0 ]; then
     if is_installed wayvnc; then
+      systemctl stop wayvnc.service
+
+      # In case wayvnc is already running via older xdg-autostart machanism
       pkill wayvnc
       if [ -e /etc/xdg/autostart/wayvnc.desktop ] ; then
         rm /etc/xdg/autostart/wayvnc.desktop
@@ -949,51 +952,9 @@ do_vnc() {
       systemctl stop vncserver-x11-serviced.service
     fi
     if is_wayfire; then
-      mkdir -p $HOMEDIR/.config/wayvnc/
-      if ! [ -e $HOMEDIR/.config/wayvnc/config ] ; then
-        cat << EOF > $HOMEDIR/.config/wayvnc/config
-use_relative_paths=true
-address=0.0.0.0
-enable_auth=true
-enable_pam=true
-private_key_file=key.pem
-certificate_file=cert.pem
-rsa_private_key_file=rsa_key.pem
-EOF
-        chown -R $USER:$USER $HOMEDIR/.config/wayvnc/config
-      fi
-      if ! [ -e $HOMEDIR/.config/wayvnc/key.pem ] || ! [ -e $HOMEDIR/.config/wayvnc/cert.pem ] ; then
-        echo "Generating key..."
-        HOSTNAME=$(cat /etc/hostname)
-        IP=$(ifconfig | grep inet | head -n 1 | cut -d ' ' -f 10)
-        openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout $HOMEDIR/.config/wayvnc/key.pem -out $HOMEDIR/.config/wayvnc/cert.pem -subj /CN=$HOSTNAME -addext subjectAltName=DNS:$HOSTNAME,DNS:$HOSTNAME,IP:$IP 2> /dev/null
-        chown -R $USER:$USER $HOMEDIR/.config/wayvnc/*.pem
-        echo "Done"
-      fi
-      if ! [ -e $HOMEDIR/.config/wayvnc/rsa_key.pem ] ; then
-        echo "Generating RSA key..."
-        ssh-keygen -m pem -f $HOMEDIR/.config/wayvnc/rsa_key.pem -t rsa -N "" > /dev/null
-        chown -R $USER:$USER $HOMEDIR/.config/wayvnc/rsa_key.pem
-        echo "Done"
-      fi
-      if is_installed wayvnc || apt-get install "$APT_GET_FLAGS" wayvnc; then
-        KBL=$(grep XKBLAYOUT /etc/default/keyboard | cut -d \" -f 2)
-        KBV=$(grep XKBVARIANT /etc/default/keyboard | cut -d \" -f 2)
-        if [ -z $KBV ] ; then
-          VNCKBD="$KBL"
-        else
-          VNCKBD="$KBL-$KBV"
-        fi
-        cat << EOF > /etc/xdg/autostart/wayvnc.desktop
-[Desktop Entry]
-Type=Application
-Name=wayvnc
-Comment=Start wayvnc
-NoDisplay=true
-Exec=/usr/bin/wayvnc --render-cursor --keyboard=$VNCKBD
-OnlyShowIn=wayfire
-EOF
-        sudo -u $USER XDG_RUNTIME_DIR=/run/user/$SUDO_UID WAYLAND_DISPLAY=wayland-1 wayvnc --render-cursor --keyboard=$VNCKBD 2> /dev/null &
+      if is_installed wayvnc; then
+        systemctl enable wayvnc.service &&
+        systemctl start wayvnc.service &&
         STATUS=enabled
       else
         return 1
@@ -1009,19 +970,12 @@ EOF
     fi
   elif [ $RET -eq 1 ]; then
     if is_installed wayvnc; then
-      pkill wayvnc
-      if [ -e /etc/xdg/autostart/wayvnc.desktop ] ; then
-        rm /etc/xdg/autostart/wayvnc.desktop
-      fi
+      systemctl disable wayvnc.service
+      systemctl stop wayvnc.service
     fi
     if is_installed realvnc-vnc-server; then
       systemctl disable vncserver-x11-serviced.service
       systemctl stop vncserver-x11-serviced.service
-    fi
-    if is_wayfire; then
-      if [ -e $HOMEDIR/.config/wayvnc/config ] ; then
-        rm $HOMEDIR/.config/wayvnc/config
-      fi
     fi
     STATUS=disabled
   else

--- a/raspi-config
+++ b/raspi-config
@@ -158,6 +158,10 @@ deb_ver () {
   echo $ver
 }
 
+get_package_version() {
+  dpkg-query --showformat='${Version}' --show "$1"
+}
+
 can_configure() {
   if [ ! -e /etc/init.d/lightdm ]; then
     return 1
@@ -939,6 +943,12 @@ do_vnc() {
   fi
   if [ $RET -eq 0 ]; then
     if is_installed wayvnc; then
+      wayvnc_version="$(get_package_version wayvnc)"
+      if dpkg --compare-versions "$wayvnc_version" lt 0.8; then
+        whiptail --msgbox "WayVNC version 0.8 or greater is required (have $wayvnc_version)" 20 60 1
+        return 1
+      fi
+
       systemctl stop wayvnc.service
 
       # In case wayvnc is already running via older xdg-autostart machanism


### PR DESCRIPTION
This re-applies #226 and adds a version check.

The `wayvnc-control` package is no longer needed. Everything has been merged into the `wayvnc` package. I have tested that this works with the wayvnc debian package built from my pios branch: https://github.com/any1/wayvnc/tree/pios

I do not recommend merging this until you have tested and released the v0.8-rc0 wayvnc package.