### PR TITLE
Fix a control issue in non-interactive mode for `do_fan()`.

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -1312,7 +1312,7 @@ do_fan() {
     whiptail --yesno "Would you like to enable fan temperature control?" $DEFAULT 20 60 2
     RET=$?
   else
-    RET=$1
+    RET=$(expr 1 - $1)
   fi
   if [ $RET -eq 0 ] ; then
     if [ "$INTERACTIVE" = True ]; then


### PR DESCRIPTION
Hi, I'm a well-known idiot so please don't roast me _too_ hard if I'm reading this wrong. I've provided an explanation of my change below.

Obv this is potentially a nightmare for backward compatibility, but I'm hoping that this has simply gone unnoticed. Maybe I'm the only guy using `raspi-config` to configure the fan non-interactively?