### PR TITLE
raspi-config: Change the NetworkManager state file when NetworkManager is enabled but not active

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -824,8 +824,12 @@ do_wifi_country() {
     wpa_cli -i "$IFACE" save_config > /dev/null 2>&1
   fi
 
-  if [ "$INIT" = "systemd" ] && ! ischroot && systemctl -q is-active NetworkManager; then
-    nmcli radio wifi on
+  if [ "$INIT" = "systemd" ] && ! ischroot && systemctl -q is-enabled NetworkManager; then
+    if systemctl -q is-active NetworkManager; then
+      nmcli radio wifi on
+    elif [ -e /var/lib/NetworkManager/NetworkManager.state ]; then
+      sed /var/lib/NetworkManager/NetworkManager.state -i -e "s/^WirelessEnabled=.*/WirelessEnabled=true/"
+    fi
   elif hash rfkill 2> /dev/null; then
     rfkill unblock wifi
   fi


### PR DESCRIPTION
do_wifi_country() does not execute nmcli when systemd.run=/boot/firstrun.sh in cmdline.txt. In this case, NetworkManager is not active, regardless of whether it is enabled or not. If wifi is blocked by NetworkManager, it cannot be unblocked on boot. Therefore, change the NetworkManager state file for this case.