### PR TITLE
Display amount of memory on the Pi

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Vcs-Browser: https://github.com/RPi-Distro/raspi-config
 
 Package: raspi-config
 Architecture: all
-Depends: ${misc:Depends}, whiptail, parted, lua5.1, alsa-utils, psmisc
+Depends: ${misc:Depends}, whiptail, parted, lua5.1, alsa-utils, psmisc, raspi-utils
 Recommends: triggerhappy, iw
 Description: Raspberry Pi configuration tool
  A simple configuration tool for common Raspberry Pi administrative tasks

--- a/raspi-config
+++ b/raspi-config
@@ -3589,7 +3589,13 @@ if [ "$INTERACTIVE" = True ]; then
   done
   while true; do
     if is_pi ; then
-      FUN=$(whiptail --title "Raspberry Pi Software Configuration Tool (raspi-config)" --backtitle "$(cat /proc/device-tree/model)" --menu "Setup Options" $WT_HEIGHT $WT_WIDTH $WT_MENU_HEIGHT --cancel-button Finish --ok-button Select \
+      MEMSIZE=$(vcgencmd get_config total_mem|cut -d= -f2)
+      if [ $MEMSIZE -lt 1024 ]; then
+        FMEMSIZE="${MEMSIZE}MB"
+      else
+        FMEMSIZE="$(expr $MEMSIZE / 1024)GB"
+      fi
+      FUN=$(whiptail --title "Raspberry Pi Software Configuration Tool (raspi-config)" --backtitle "$(cat /proc/device-tree/model), ${FMEMSIZE}" --menu "Setup Options" $WT_HEIGHT $WT_WIDTH $WT_MENU_HEIGHT --cancel-button Finish --ok-button Select \
         "1 System Options" "Configure system settings" \
         "2 Display Options" "Configure display settings" \
         "3 Interface Options" "Configure connections to peripherals" \


### PR DESCRIPTION
Raspberry Pi 4 and Raspberry Pi 5 come in board-variants with differing amounts of RAM, so it seems like it might be nice to display that info next to where the Pi model and revision are displayed.

Example screenshots:
![Screenshot from 2024-06-01 01-05-59](https://github.com/RPi-Distro/raspi-config/assets/476186/4a861ac1-727f-42a9-8fd5-69f3ab728649)

![Screenshot from 2024-06-01 01-05-21](https://github.com/RPi-Distro/raspi-config/assets/476186/1b9d828c-c865-4284-be1d-8271c5d859c0)

![Screenshot from 2024-06-01 01-04-34](https://github.com/RPi-Distro/raspi-config/assets/476186/7272e153-62cf-4f42-8544-9214eff7cfae)
