### PR TITLE
Use brightnessctl instead of wlopm for screen blanking on labwc

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -565,7 +565,8 @@ do_blanking() {
       ASK_TO_REBOOT=1
     fi
     if [ "$RET" -eq 0 ] ; then
-      echo "swayidle -w timeout 600 'wlopm --off \\*' resume 'wlopm --on \\*' &" >> $LABWCAST_FILE
+      DEBIAN_FRONTEND=noninteractive apt install brightnessctl -y
+      echo "swayidle -w timeout 600 'brightnessctl -d \* -q set 0' resume 'brightnessctl -d \* -q set 100' &" >> $LABWCAST_FILE
       STATUS=enabled
     elif [ "$RET" -eq 1 ]; then
       sed -i '/swayidle/d' $LABWCAST_FILE

--- a/raspi-config
+++ b/raspi-config
@@ -565,9 +565,12 @@ do_blanking() {
       ASK_TO_REBOOT=1
     fi
     if [ "$RET" -eq 0 ] ; then
-      DEBIAN_FRONTEND=noninteractive apt install brightnessctl -y
-      echo "swayidle -w timeout 600 'brightnessctl -d \* -q set 0' resume 'brightnessctl -d \* -q set 100' &" >> $LABWCAST_FILE
-      STATUS=enabled
+      if is_installed brightnessctl || apt install -y brightnessctl; then
+        echo "swayidle -w timeout 600 'brightnessctl -d \* -q set 0' resume 'brightnessctl -d \* -q set 100' &" >> $LABWCAST_FILE
+        STATUS=enabled
+      else
+        return 1
+      fi
     elif [ "$RET" -eq 1 ]; then
       sed -i '/swayidle/d' $LABWCAST_FILE
       STATUS=disabled


### PR DESCRIPTION
I noticed that when using the labwc compositor the wlopm command is unable to set the power mode for the display on the first instance of the compositor. For instance if I try to run `wlopm --off \*` in the terminal on my raspberry's display it will say `ERROR: Setting power mode for output 'DPI-1' failed.` if I launch labwc on another tty session so Ctrl+Alt+F6 and labwc-pi, the wlopm command can set the power mode. So while trying to fix the issue I came across the `brightnessctl` tool ([github](https://github.com/Hummer12007/brightnessctl)), which is a simple tool to set the brightness of displays. So after replacing the screen blanking command to `swayidle -w timeout 600 'brightnessctl -d \* -q set 0' resume 'brightnessctl -d \* -q set 100' &` the screen blanking finally worked flawlessly like it used too.