### PR TITLE
Add support for Raspberry Pi Connect 1.3.0

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -1130,19 +1130,27 @@ do_rpi_connect() {
   fi
   if [ $RET -eq 0 ]; then
     if is_installed rpi-connect || apt-get install "$APT_GET_FLAGS" rpi-connect; then
-      systemctl --global -q enable rpi-connect.service
-      $PREFIX systemctl --global -q start rpi-connect.service
-      systemctl --global -q enable rpi-connect-wayvnc.service
-      $PREFIX systemctl --global -q start rpi-connect-wayvnc.service
+      rpi_connect_version="$(get_package_version rpi-connect)"
+      if dpkg --compare-versions "$rpi_connect_version" lt 1.3; then
+        systemctl --global -q enable rpi-connect.service rpi-connect-wayvnc.service
+        $PREFIX systemctl --global -q start rpi-connect.service rpi-connect-wayvnc.service
+      else
+        systemctl --global -q enable rpi-connect.service rpi-connect-wayvnc.service rpi-connect-wayvnc-watcher.path
+        $PREFIX systemctl --global -q start rpi-connect.service
+      fi
       STATUS=enabled
     else
       return 1
     fi
   elif [ $RET -eq 1 ]; then
-    systemctl --global -q disable rpi-connect-wayvnc.service
-    $PREFIX systemctl --global -q stop rpi-connect-wayvnc.service
-    systemctl --global -q disable rpi-connect.service
-    $PREFIX systemctl --global -q stop rpi-connect.service
+    rpi_connect_version="$(get_package_version rpi-connect)"
+    if dpkg --compare-versions "$rpi_connect_version" lt 1.3; then
+      $PREFIX systemctl --global -q stop rpi-connect.service rpi-connect-wayvnc.service
+      systemctl --global -q disable rpi-connect-wayvnc.service rpi-connect.service
+    else
+      $PREFIX systemctl --global -q stop rpi-connect.service
+      systemctl --global -q disable rpi-connect.service rpi-connect-wayvnc.service rpi-connect-wayvnc-watcher.path
+    fi
     STATUS=disabled
   else
     return $RET


### PR DESCRIPTION
Raspberry Pi Connect 1.3.0 adds a new rpi-connect-wayvnc-watcher.path systemd unit that needs to be enabled so that rpi-connectd is informed of the WayVNC service starting and stopping. It also makes any dependent services "PartOf" the main rpi-connect.service so we no longer need to explicitly stop or start them individually.

As rpi-connect 1.2.2 is included in the July 4th 2024 Raspberry Pi OS image, we support both new and old versions, keeping the old logic for stopping and starting rpi-connectd and its related services.
