### PR TITLE
Update raspi-config - allow disable_overlayfs to do its job even if a…

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -3063,8 +3063,9 @@ disable_overlayfs() {
   fi
 
   # modify command line
-  sed -i $CMDLINE -e "s/\(.*\)overlayroot=tmpfs \(.*\)/\1\2/"
-
+  if ! sed -i $CMDLINE -e "s/\(.*\)overlayroot=tmpfs[^ ]* \(.*\)/\1\2/" ; then
+    echo "Unable to remove overlayroot call from cmdline.txt - cannot disable"
+  fi
   if [ "$BOOTRO" = "yes" ] ; then
     if ! mount -o remount,ro /boot${FIRMWARE} 2>/dev/null ; then
       echo "Unable to remount boot partition as read-only"


### PR DESCRIPTION
…dditional parameters have been added by the user, also, check for error state and report it back.

The creators of raspi-config took a KISS approach to adding overlayroot support - /boot is excluded by default, unless requested by the user (plus overlayroot can't handle vfat anyway).
Which means adding the overlay parameter to cmdline.txt, which is stored under /boot or /boot/firmware, makes removing it easy as well, as it should always be writable or at least trivial to make /boot writable with a simple "mount -o remount,rw" call.
The downside of this is that all entries in /etc/overlayroot.conf and /etc/overlayroot.local.conf are being ignored, as kernel boot parameters will always take precedence (per the spec in the overlayroot documentation). This means that users who wish to add additional parameters to the overlayfs string must do so in cmdline.txt.
One such common addition would be ":recurse=0" to exclude mountpoints below "/" from being covered by overlayroot - this is handy for additional partitions being mounted as data storage or homedirectories. That way, these can be used for persistent storage, yet "/" is protected from catastrophic file system damage so the base system will always boot up.

Adding additional parameters, however, breaks raspi-config's ability to disable overlayfs, because it is looking for the exact string, followed by a blank space. This patch checks for "expected string plus anything trailing that IS NOT a blank space", and will remove it - this SHOULD be safe to do as spaces are not valid characters within an overlayfs string, from what I can tell.

It also adds a simple check in case sed exited with an error state, and will report it with an error message similar in style to the ones already used in this function.