### PR TITLE
Update rpi-connect version check

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -1120,7 +1120,7 @@ do_rpi_connect() {
       if dpkg --compare-versions "$rpi_connect_version" lt 1.3; then
         $PREFIX systemctl --user -q enable rpi-connect.service rpi-connect-wayvnc.service
         $PREFIX systemctl --user -q start rpi-connect.service rpi-connect-wayvnc.service
-      elif dpkg --compare-versions "$rpi_connect_version" lt 1.5; then
+      elif dpkg --compare-versions "$rpi_connect_version" lt 2.0; then
         $PREFIX systemctl --user -q enable rpi-connect.service rpi-connect-wayvnc.service rpi-connect-wayvnc-watcher.path
         $PREFIX systemctl --user -q start rpi-connect.service
       else
@@ -1137,7 +1137,7 @@ do_rpi_connect() {
     fi
     if [ $RET -eq 0 ]; then
       if is_installed rpi-connect || is_installed rpi-connect-lite || apt-get install "$APT_GET_FLAGS" rpi-connect-lite; then
-        if dpkg --compare-versions "$rpi_connect_version" lt 1.5; then
+        if dpkg --compare-versions "$rpi_connect_version" lt 2.0; then
           $PREFIX systemctl --user -q enable rpi-connect.service
           $PREFIX systemctl --user -q start rpi-connect.service
         else
@@ -1151,7 +1151,7 @@ do_rpi_connect() {
       if dpkg --compare-versions "$rpi_connect_version" lt 1.3; then
         $PREFIX systemctl --user -q stop rpi-connect.service rpi-connect-wayvnc.service
         $PREFIX systemctl --user -q disable rpi-connect-wayvnc.service rpi-connect.service
-      elif dpkg --compare-versions "$rpi_connect_version" lt 1.5; then
+      elif dpkg --compare-versions "$rpi_connect_version" lt 2.0; then
         $PREFIX systemctl --user -q stop rpi-connect.service
         $PREFIX systemctl --user -q disable rpi-connect.service rpi-connect-wayvnc.service rpi-connect-wayvnc-watcher.path
       else


### PR DESCRIPTION
The new rpi-connect on and rpi-connect off commands will be in 2.0.0, not 1.5.0.