### PR TITLE
Add USER overwrite option in for `do_boot_behaviour`

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -1773,7 +1773,9 @@ do_boot_behaviour() {
       3>&1 1>&2 2>&3)
   else
     BOOTOPT=$1
-    true
+    if [ -n "$2" ]; then
+      USER=$2
+    fi
   fi
   if [ $? -eq 0 ]; then
     case "$BOOTOPT" in # Handle default target


### PR DESCRIPTION
This adds the option to overwrite the USER variable in the `do_boot_behaviour` function with a custom parameter. 
This is useful if running in a boot environment before the `systemd-user-sessions` service.
