### PR TITLE
Fix `do_serial_cons` function for Raspberry Pi 5

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -1359,7 +1359,11 @@ get_serial_hw() {
 
 do_serial_cons() {
   if [ $1 -eq 0 ] ; then
-    if grep -q "console=ttyAMA0" $CMDLINE ; then
+    if is_pifive ; then
+      if [ -e /proc/device-tree/aliases/serial0 ]; then
+        sed -i $CMDLINE -e "s/console=serial0/console=ttyAMA0/"
+      fi
+    elif grep -q "console=ttyAMA0" $CMDLINE ; then
       if [ -e /proc/device-tree/aliases/serial0 ]; then
         sed -i $CMDLINE -e "s/console=ttyAMA0/console=serial0/"
       fi
@@ -1371,8 +1375,12 @@ do_serial_cons() {
       fi
     fi
   else
-    sed -i $CMDLINE -e "s/console=ttyAMA0,[0-9]\+ //"
-    sed -i $CMDLINE -e "s/console=serial0,[0-9]\+ //"
+    if is_pifive ; then
+      sed -i $CMDLINE -e "s/console=ttyAMA0/console=serial0/"
+    else
+      sed -i $CMDLINE -e "s/console=ttyAMA0,[0-9]\+ //"
+      sed -i $CMDLINE -e "s/console=serial0,[0-9]\+ //"
+    fi
   fi
 }
 


### PR DESCRIPTION
I found a bug in the `do_serial_cons` function in `raspi-config` at Raspberry Pi 5. On previous Raspberry Pi devices under Raspberry Pi 4, `console=serial0` in cmdline.txt allows the login shell via UART works correctly. However, on Raspberry Pi 5 devices, `console=ttyAMA0` makes login shell via UART to work.

I considered just posting the issue, but I want to contribute to the open-source project, so I decided to submit a pull request.

- Tested on Raspberry Pi 5 & 4 (latest as of 2024-12-21)

  [neofetch output of Pi 5]
  - OS: `Debian GNU/Linux 12 (bookworm) aarch64`
  - Host: `Raspberry Pi 5 Model B Rev 1.0`
  - Kernel: `6.6.51+rpt-rpi-2712`
  - `raspi-config` Version: `20211221`

  [neofetch output of Pi 4]
  - OS: `Debian GNU/Linux 12 (bookworm) aarch64`
  - Host: `Raspberry Pi 4 Model B Rev 1.4`
  - Kernel: 1`6.6.51+rpt-rpi-v8`
  - `raspi-config` Version: `20211221`