### PR TITLE
Add configuration for AB firmware updates

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -2191,6 +2191,9 @@ get_ab_firmware() {
 }
 
 do_ab_firmware() {
+  if ! is_pifive ; then
+    return 1
+  fi
   SPIDEV="spi10"
   if [ "$(get_ab_firmware)" -eq 0 ]; then
     CURRENT="B1"

--- a/raspi-config
+++ b/raspi-config
@@ -2181,6 +2181,68 @@ do_network_install_ui() {
   fi
  }
 
+get_ab_firmware() {
+  SPIDEV="spi10"
+  if grep -q "^dtoverlay=no$SPIDEV" "$CONFIG" ; then
+    echo 0
+  else
+    echo 1
+  fi
+}
+
+do_ab_firmware() {
+  SPIDEV="spi10"
+  CURRENT=0
+  if [ "$(get_ab_firmware)" -eq 0 ]; then
+    CURRENT="B1 Enable"
+  else
+    CURRENT="B2 Disable"
+  fi
+  if [ "$INTERACTIVE" = True ]; then
+    RET=$(whiptail --title "Raspberry Pi Software Configuration Tool (raspi-config)" --default-item "$CURRENT" \
+      --menu "AB firmware updates" $WT_HEIGHT $WT_WIDTH $WT_MENU_HEIGHT \
+      "B1 Enable" "Enable AB firmware updates (warning: Flashrom cannot be used for firmware updates)" \
+      "B2 Disable" "Disable AB firmware updates" \
+      3>&1 1>&2 2>&3)
+  else
+    RET=$1
+    true
+  fi
+  if [ $? -eq 0 ]; then
+    case "$RET" in
+      B1*)
+        if [ "$CURRENT" = "B2 Disable" ]; then
+          ASK_TO_REBOOT=1
+        fi
+        sed "$CONFIG" -i -e "s/^#dtoverlay=no$SPIDEV.*/dtoverlay=no$SPIDEV/"
+        if ! grep -q "^dtoverlay=no$SPIDEV" "$CONFIG"; then
+          if ! tail -1 "$CONFIG" | grep -q "\\[all\\]" ; then
+            printf "[all]\n" >> "$CONFIG"
+          fi
+          printf "dtoverlay=no$SPIDEV\n" >> "$CONFIG"
+        fi
+        STATUS=enabled
+        ;;
+      B2*)
+        if [ "$CURRENT" = "B1 Enable" ]; then
+          ASK_TO_REBOOT=1
+        fi
+        sed "$CONFIG" -i -e "s/^dtoverlay=no$SPIDEV.*/#dtoverlay=no$SPIDEV/"
+        STATUS=disabled
+        ;;
+      *)
+        whiptail --msgbox "Programmer error, unrecognised boot option" 20 60 2
+        return 1
+        ;;
+    esac
+  else
+    return 0
+  fi
+  if [ "$INTERACTIVE" = True ]; then
+    whiptail --msgbox "AB firmware updates are $STATUS" 20 60 1
+  fi
+}
+
 # shellcheck disable=SC2120
 do_power_off_on_halt() {
   if [ "$INTERACTIVE" = True ]; then
@@ -4152,6 +4214,7 @@ do_advanced_menu() {
       "A11 Logging" "Set storage location for logs" \
       "A12 WLAN Power Save" "Enable/disable WLAN power saving" \
       "A13 Link-local Fallback" "Enable/disable link-local address fallback" \
+      "A14 AB Firmware" "Enable/disable AB firmware updates" \
       3>&1 1>&2 2>&3)
   elif is_pifour ; then
     FUN=$(whiptail --title "Raspberry Pi Software Configuration Tool (raspi-config)" --menu "Advanced Options" $WT_HEIGHT $WT_WIDTH $WT_MENU_HEIGHT --cancel-button Back --ok-button Select \
@@ -4208,6 +4271,7 @@ do_advanced_menu() {
       A11\ *) do_journald_storage ;;
       A12\ *) do_wifi_power_save ;;
       A13\ *) do_link_local_fallback ;;
+      A14\ *) do_ab_firmware ;;
       *) whiptail --msgbox "Programmer error: unrecognized option" 20 60 1 ;;
     esac || whiptail --msgbox "There was an error running option $FUN" 20 60 1
   fi

--- a/raspi-config
+++ b/raspi-config
@@ -2233,7 +2233,7 @@ do_ab_firmware() {
         STATUS=disabled
         ;;
       *)
-        whiptail --msgbox "Programmer error, unrecognised boot option" 20 60 2
+        whiptail --msgbox "Programmer error, unrecognised option" 20 60 2
         return 1
         ;;
     esac

--- a/raspi-config
+++ b/raspi-config
@@ -2193,15 +2193,15 @@ get_ab_firmware() {
 do_ab_firmware() {
   SPIDEV="spi10"
   if [ "$(get_ab_firmware)" -eq 0 ]; then
-    CURRENT="B1 Enable"
+    CURRENT="B1"
   else
-    CURRENT="B2 Disable"
+    CURRENT="B2"
   fi
   if [ "$INTERACTIVE" = True ]; then
     RET=$(whiptail --title "Raspberry Pi Software Configuration Tool (raspi-config)" --default-item "$CURRENT" \
       --menu "AB firmware updates" $WT_HEIGHT $WT_WIDTH $WT_MENU_HEIGHT \
-      "B1 Enable" "Enable AB firmware updates (warning: Flashrom cannot be used for firmware updates)" \
-      "B2 Disable" "Disable AB firmware updates" \
+      "B1" "Enable AB firmware updates (warning: Flashrom cannot be used for firmware updates)" \
+      "B2" "Disable AB firmware updates" \
       3>&1 1>&2 2>&3)
   else
     RET=$1
@@ -2210,7 +2210,7 @@ do_ab_firmware() {
   if [ $? -eq 0 ]; then
     case "$RET" in
       B1*)
-        if [ "$CURRENT" = "B2 Disable" ]; then
+        if [ "$CURRENT" = "B2" ]; then
           ASK_TO_REBOOT=1
         fi
         sed -i -e "s/^#dtoverlay=no$SPIDEV.*/dtoverlay=no$SPIDEV/" "$CONFIG"
@@ -2223,7 +2223,7 @@ do_ab_firmware() {
         STATUS=enabled
         ;;
       B2*)
-        if [ "$CURRENT" = "B1 Enable" ]; then
+        if [ "$CURRENT" = "B1" ]; then
           ASK_TO_REBOOT=1
         fi
         sed -i -e "s/^dtoverlay=no$SPIDEV.*/#dtoverlay=no$SPIDEV/" "$CONFIG"

--- a/raspi-config
+++ b/raspi-config
@@ -2213,7 +2213,7 @@ do_ab_firmware() {
         if [ "$CURRENT" = "B2 Disable" ]; then
           ASK_TO_REBOOT=1
         fi
-        sed "$CONFIG" -i -e "s/^#dtoverlay=no$SPIDEV.*/dtoverlay=no$SPIDEV/"
+        sed -i -e "s/^#dtoverlay=no$SPIDEV.*/dtoverlay=no$SPIDEV/" "$CONFIG"
         if ! grep -q "^dtoverlay=no$SPIDEV" "$CONFIG"; then
           if ! tail -1 "$CONFIG" | grep -q "\\[all\\]" ; then
             printf "[all]\n" >> "$CONFIG"
@@ -2226,7 +2226,7 @@ do_ab_firmware() {
         if [ "$CURRENT" = "B1 Enable" ]; then
           ASK_TO_REBOOT=1
         fi
-        sed "$CONFIG" -i -e "s/^dtoverlay=no$SPIDEV.*/#dtoverlay=no$SPIDEV/"
+        sed -i -e "s/^dtoverlay=no$SPIDEV.*/#dtoverlay=no$SPIDEV/" "$CONFIG"
         STATUS=disabled
         ;;
       *)

--- a/raspi-config
+++ b/raspi-config
@@ -2192,7 +2192,6 @@ get_ab_firmware() {
 
 do_ab_firmware() {
   SPIDEV="spi10"
-  CURRENT=0
   if [ "$(get_ab_firmware)" -eq 0 ]; then
     CURRENT="B1 Enable"
   else

--- a/raspi-config
+++ b/raspi-config
@@ -2218,7 +2218,7 @@ do_ab_firmware() {
           if ! tail -1 "$CONFIG" | grep -q "\\[all\\]" ; then
             printf "[all]\n" >> "$CONFIG"
           fi
-          printf "dtoverlay=no$SPIDEV\n" >> "$CONFIG"
+          printf 'dtoverlay=no%s\n' "$SPIDEV" >> "$CONFIG"
         fi
         STATUS=enabled
         ;;


### PR DESCRIPTION
Enabling AB firmware updates adds nospi dtoverlay. This allows the firmware to still access EEPROM after boot so that AB updates can be preformed.