### PR TITLE
Migrate beta repo config to deb822 format

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -2381,13 +2381,25 @@ do_beta_mode() {
         if is_pifour || is_pifive ; then
           sed /etc/default/rpi-eeprom-update -i -e "s/^FIRMWARE_RELEASE_STATUS.*/FIRMWARE_RELEASE_STATUS=\"latest\"/"
         fi
-        cat > /etc/apt/sources.list.d/beta.list << EOF
-deb http://archive.raspberrypi.com/debian/ $DVER beta
-#deb-src http://archive.raspberrypi.com/debian/ $DVER beta
+        cat > /etc/apt/sources.list.d/beta.sources << EOF
+Types: deb
+URIs: http://archive.raspberrypi.com/debian/
+Suites: $DVER
+Components: beta
+
+Types: deb-src
+Enabled: no
+URIs: http://archive.raspberrypi.com/debian/
+Suites: $DVER
+Components: beta
 EOF
+        # Remove old-style list if present
+        rm -f /etc/apt/sources.list.d/beta.list
+
         BETA="Beta"
         ;;
       B2*)
+        rm -f /etc/apt/sources.list.d/beta.sources
         rm -f /etc/apt/sources.list.d/beta.list
         BETA="Release"
         ;;


### PR DESCRIPTION
apt has supported the deb822 `.sources` file format since at least Debian Stretch. Debian's [current APT documentation](https://manpages.debian.org/trixie/apt/sources.list.5.en.html#DEB822-STYLE_FORMAT) recommends migrating to the deb822 format and notes that the old one-line format is being deprecated

